### PR TITLE
6039 - ET - Improve the console output on debug mode to display more accurate timing.

### DIFF
--- a/dist/zerv-ng-sync-mock.js
+++ b/dist/zerv-ng-sync-mock.js
@@ -1,12 +1,12 @@
 (function() {
-'use strict';
+"use strict";
 
 angular
     .module('sync.test', ['zerv.sync']);
 }());
 
 (function() {
-'use strict';
+"use strict";
 
 angular
     .module('sync.test')
@@ -22,7 +22,7 @@ function mockSocketio() {
 
 
     this.$get =
-        ['$rootScope', '$pq', function($rootScope, $pq) {
+        ["$rootScope", "$pq", function($rootScope, $pq) {
             var self = this;
             this.network = true;
             var events = {},
@@ -108,21 +108,23 @@ function mockSocketio() {
 }());
 
 (function() {
-'use strict';
+"use strict";
 
 angular
     .module('sync.test')
     .provider('mockSyncServer', mockSyncServer);
 
 function mockSyncServer() {
+
     var debug;
 
-    this.setDebug = function(value) {
+    this.setDebug = function (value) {
         debug = value;
     };
 
 
-    this.$get = ['$rootScope', '$pq', '$socketio', '$sync', 'publicationService', function sync($rootScope, $pq, $socketio, $sync, publicationService) {
+    this.$get = ["$rootScope", "$pq", "$socketio", "$sync", "publicationService", function sync($rootScope, $pq, $socketio, $sync, publicationService) {
+
         var publicationsWithSubscriptions = publicationService;
         var subCount = 0;
 
@@ -143,14 +145,15 @@ function mockSyncServer() {
             acknowledge: acknowledge,
 
 
-            setData: setData,
-        };
 
-        $socketio.onFetch('sync.subscribe', function() {
+            setData: setData
+        }
+
+        $socketio.onFetch('sync.subscribe', function () {
             return service.subscribe.apply(self, arguments);
         });
 
-        $socketio.onFetch('sync.unsubscribe', function() {
+        $socketio.onFetch('sync.unsubscribe', function () {
             return service.unsubscribe.apply(self, arguments);
         });
 
@@ -205,7 +208,7 @@ function mockSyncServer() {
          */
         function publish(definition) {
             if (_.isArray(definition)) {
-                _.forEach(definition, function(def) {
+                _.forEach(definition, function (def) {
                     if (!def.type) {
                         throw new Error('Publish array argument must contain objects with a type property ("object" or "array")');
                     }
@@ -214,7 +217,7 @@ function mockSyncServer() {
                     } else {
                         publishObject(def.sub, def.data);
                     }
-                });
+                })
             } else if (_.isObject(definition)) {
                 publishObject(definition.sub, definition.data);
             } else {
@@ -229,13 +232,15 @@ function mockSyncServer() {
          *   if not provided, a default publication will be created
          */
         function setData(subParams, data) {
-            data.forEach(function(record) {
+            data.forEach(function (record) {
                 if (_.isNil(record.revision)) {
                     throw new Error('Objects in publication must have a revision and id. Check you unit test data for ' + JSON.stringify(subParams));
                 }
             });
             return publicationsWithSubscriptions.create(data, subParams.publication, subParams.params);
         }
+
+
 
 
         function notifyDataUpdate(subParams, data) {
@@ -256,20 +261,18 @@ function mockSyncServer() {
             }
 
             data = publication.remove(data);
-            _.forEach(data, function(record) {
- record.remove = new Date();
-});
+            _.forEach(data, function (record) { record.remove = new Date(); });
             return notifySubscriptions(publication, data);
         }
 
         function notifySubscriptions(publication, data) {
-            var r = $pq.all(_.map(publication.subscriptionIds, function(id) {
+            var r = $pq.all(_.map(publication.subscriptionIds, function (id) {
                 return onPublicationNotficationCallback({
                     name: publication.name,
                     subscriptionId: id,
                     params: publication.params,
                     records: data,
-                    diff: true,
+                    diff: true
                 }, service.acknowledge);
             }));
             if (!$rootScope.$$phase) {
@@ -279,6 +282,7 @@ function mockSyncServer() {
                 // when the digest completes, the notification has been processed by the client, UI might have reacted too.
             }
             return r;
+
         }
 
         function subscribe(subParams) {
@@ -302,11 +306,11 @@ function mockSyncServer() {
                 publication.subscriptionIds.push(subId);
             }
 
-            return $pq.resolve(subId).then(function(subId) {
+            return $pq.resolve(subId).then(function (subId) {
                 publication.subId = subId;
                 onPublicationNotficationCallback({
                     name: publication.name,
-                    subscriptionId: subId, // this is the id for the new subscription.
+                    subscriptionId: subId,  // this is the id for the new subscription.
                     params: publication.params,
                     records: publication.getData(),
                 }, service.acknowledge);
@@ -316,7 +320,7 @@ function mockSyncServer() {
 
         function unsubscribe(subParams) {
             publicationsWithSubscriptions.release(subParams.id, subParams.publication, subParams.params);
-            logDebug('Unsubscribed: ' + JSON.stringify(subParams));
+            logDebug("Unsubscribed: " + JSON.stringify(subParams));
             return $pq.resolve();
         }
 
@@ -338,14 +342,14 @@ function mockSyncServer() {
                 console.debug('MOCKSERV: ' + msg);
             }
         }
-    }];
+    }]
 }
 }());
 
 (function() {
-'use strict';
+"use strict";
 
-publicationService.$inject = ['$sync'];
+publicationService.$inject = ["$sync"];
 angular
     .module('sync.test')
     .service('publicationService', publicationService);
@@ -360,14 +364,14 @@ function publicationService($sync) {
 
     function findBySubscriptionId(id) {
         // find the data for this subscription
-        return _.find(publications, function(pub) {
+        return _.find(publications, function (pub) {
             return _.indexOf(pub.subscriptionIds, id) !== -1;
         });
     }
 
     function find(name, params) {
         // find the data for this subscription
-        return _.find(publications, function(pub) {
+        return _.find(publications, function (pub) {
             return pub.name === name && (
                 (params && pub.params && _.isEqual(params, pub.params)) ||
                 (!params && !pub.params)
@@ -398,14 +402,15 @@ function publicationService($sync) {
     }
 
 
+
     function copyAll(array) {
         var r = [];
-        array.forEach(function(i) {
+        array.forEach(function (i) {
             if (!_.isObject(i)) {
                 throw new Error('Publication data cannot be null');
             }
             r.push(angular.copy(i));
-        });
+        })
         return r;
     }
 
@@ -416,36 +421,36 @@ function publicationService($sync) {
         this.subscriptionIds = [];
     }
 
-    Publication.prototype.hasSubscriptions = function() {
+    Publication.prototype.hasSubscriptions = function () {
         return this.subscriptionIds.length > 0;
-    };
+    }
 
-    Publication.prototype.reset = function(data) {
+    Publication.prototype.reset = function (data) {
         this.cache = {};
         this.update(data);
         return data;
-    };
+    }
 
-    Publication.prototype.update = function(data) {
+    Publication.prototype.update = function (data) {
         var self = this;
         data = copyAll(data);
-        data.forEach(function(record) {
+        data.forEach(function (record) {
             self.cache[$sync.getIdValue(record.id)] = record;
         });
         return data;
-    };
+    }
 
-    Publication.prototype.remove = function(data) {
+    Publication.prototype.remove = function (data) {
         var self = this;
         data = copyAll(data);
-        data.forEach(function(record) {
+        data.forEach(function (record) {
             delete self.cache[$sync.getIdValue(record.id)];
         });
         return data;
-    };
+    }
 
-    Publication.prototype.getData = function() {
+    Publication.prototype.getData = function () {
         return _.values(this.cache);
-    };
+    }
 }
 }());

--- a/dist/zerv-ng-sync-mock.js
+++ b/dist/zerv-ng-sync-mock.js
@@ -1,12 +1,12 @@
 (function() {
-"use strict";
+'use strict';
 
 angular
     .module('sync.test', ['zerv.sync']);
 }());
 
 (function() {
-"use strict";
+'use strict';
 
 angular
     .module('sync.test')
@@ -22,7 +22,7 @@ function mockSocketio() {
 
 
     this.$get =
-        ["$rootScope", "$pq", function($rootScope, $pq) {
+        ['$rootScope', '$pq', function($rootScope, $pq) {
             var self = this;
             this.network = true;
             var events = {},
@@ -108,23 +108,21 @@ function mockSocketio() {
 }());
 
 (function() {
-"use strict";
+'use strict';
 
 angular
     .module('sync.test')
     .provider('mockSyncServer', mockSyncServer);
 
 function mockSyncServer() {
-
     var debug;
 
-    this.setDebug = function (value) {
+    this.setDebug = function(value) {
         debug = value;
     };
 
 
-    this.$get = ["$rootScope", "$pq", "$socketio", "$sync", "publicationService", function sync($rootScope, $pq, $socketio, $sync, publicationService) {
-
+    this.$get = ['$rootScope', '$pq', '$socketio', '$sync', 'publicationService', function sync($rootScope, $pq, $socketio, $sync, publicationService) {
         var publicationsWithSubscriptions = publicationService;
         var subCount = 0;
 
@@ -145,15 +143,14 @@ function mockSyncServer() {
             acknowledge: acknowledge,
 
 
+            setData: setData,
+        };
 
-            setData: setData
-        }
-
-        $socketio.onFetch('sync.subscribe', function () {
+        $socketio.onFetch('sync.subscribe', function() {
             return service.subscribe.apply(self, arguments);
         });
 
-        $socketio.onFetch('sync.unsubscribe', function () {
+        $socketio.onFetch('sync.unsubscribe', function() {
             return service.unsubscribe.apply(self, arguments);
         });
 
@@ -208,7 +205,7 @@ function mockSyncServer() {
          */
         function publish(definition) {
             if (_.isArray(definition)) {
-                _.forEach(definition, function (def) {
+                _.forEach(definition, function(def) {
                     if (!def.type) {
                         throw new Error('Publish array argument must contain objects with a type property ("object" or "array")');
                     }
@@ -217,7 +214,7 @@ function mockSyncServer() {
                     } else {
                         publishObject(def.sub, def.data);
                     }
-                })
+                });
             } else if (_.isObject(definition)) {
                 publishObject(definition.sub, definition.data);
             } else {
@@ -232,15 +229,13 @@ function mockSyncServer() {
          *   if not provided, a default publication will be created
          */
         function setData(subParams, data) {
-            data.forEach(function (record) {
+            data.forEach(function(record) {
                 if (_.isNil(record.revision)) {
                     throw new Error('Objects in publication must have a revision and id. Check you unit test data for ' + JSON.stringify(subParams));
                 }
             });
             return publicationsWithSubscriptions.create(data, subParams.publication, subParams.params);
         }
-
-
 
 
         function notifyDataUpdate(subParams, data) {
@@ -261,18 +256,20 @@ function mockSyncServer() {
             }
 
             data = publication.remove(data);
-            _.forEach(data, function (record) { record.remove = new Date(); });
+            _.forEach(data, function(record) {
+ record.remove = new Date();
+});
             return notifySubscriptions(publication, data);
         }
 
         function notifySubscriptions(publication, data) {
-            var r = $pq.all(_.map(publication.subscriptionIds, function (id) {
+            var r = $pq.all(_.map(publication.subscriptionIds, function(id) {
                 return onPublicationNotficationCallback({
                     name: publication.name,
                     subscriptionId: id,
                     params: publication.params,
                     records: data,
-                    diff: true
+                    diff: true,
                 }, service.acknowledge);
             }));
             if (!$rootScope.$$phase) {
@@ -282,7 +279,6 @@ function mockSyncServer() {
                 // when the digest completes, the notification has been processed by the client, UI might have reacted too.
             }
             return r;
-
         }
 
         function subscribe(subParams) {
@@ -306,11 +302,11 @@ function mockSyncServer() {
                 publication.subscriptionIds.push(subId);
             }
 
-            return $pq.resolve(subId).then(function (subId) {
+            return $pq.resolve(subId).then(function(subId) {
                 publication.subId = subId;
                 onPublicationNotficationCallback({
                     name: publication.name,
-                    subscriptionId: subId,  // this is the id for the new subscription.
+                    subscriptionId: subId, // this is the id for the new subscription.
                     params: publication.params,
                     records: publication.getData(),
                 }, service.acknowledge);
@@ -320,7 +316,7 @@ function mockSyncServer() {
 
         function unsubscribe(subParams) {
             publicationsWithSubscriptions.release(subParams.id, subParams.publication, subParams.params);
-            logDebug("Unsubscribed: " + JSON.stringify(subParams));
+            logDebug('Unsubscribed: ' + JSON.stringify(subParams));
             return $pq.resolve();
         }
 
@@ -342,14 +338,14 @@ function mockSyncServer() {
                 console.debug('MOCKSERV: ' + msg);
             }
         }
-    }]
+    }];
 }
 }());
 
 (function() {
-"use strict";
+'use strict';
 
-publicationService.$inject = ["$sync"];
+publicationService.$inject = ['$sync'];
 angular
     .module('sync.test')
     .service('publicationService', publicationService);
@@ -364,14 +360,14 @@ function publicationService($sync) {
 
     function findBySubscriptionId(id) {
         // find the data for this subscription
-        return _.find(publications, function (pub) {
+        return _.find(publications, function(pub) {
             return _.indexOf(pub.subscriptionIds, id) !== -1;
         });
     }
 
     function find(name, params) {
         // find the data for this subscription
-        return _.find(publications, function (pub) {
+        return _.find(publications, function(pub) {
             return pub.name === name && (
                 (params && pub.params && _.isEqual(params, pub.params)) ||
                 (!params && !pub.params)
@@ -402,15 +398,14 @@ function publicationService($sync) {
     }
 
 
-
     function copyAll(array) {
         var r = [];
-        array.forEach(function (i) {
+        array.forEach(function(i) {
             if (!_.isObject(i)) {
                 throw new Error('Publication data cannot be null');
             }
             r.push(angular.copy(i));
-        })
+        });
         return r;
     }
 
@@ -421,36 +416,36 @@ function publicationService($sync) {
         this.subscriptionIds = [];
     }
 
-    Publication.prototype.hasSubscriptions = function () {
+    Publication.prototype.hasSubscriptions = function() {
         return this.subscriptionIds.length > 0;
-    }
+    };
 
-    Publication.prototype.reset = function (data) {
+    Publication.prototype.reset = function(data) {
         this.cache = {};
         this.update(data);
         return data;
-    }
+    };
 
-    Publication.prototype.update = function (data) {
+    Publication.prototype.update = function(data) {
         var self = this;
         data = copyAll(data);
-        data.forEach(function (record) {
+        data.forEach(function(record) {
             self.cache[$sync.getIdValue(record.id)] = record;
         });
         return data;
-    }
+    };
 
-    Publication.prototype.remove = function (data) {
+    Publication.prototype.remove = function(data) {
         var self = this;
         data = copyAll(data);
-        data.forEach(function (record) {
+        data.forEach(function(record) {
             delete self.cache[$sync.getIdValue(record.id)];
         });
         return data;
-    }
+    };
 
-    Publication.prototype.getData = function () {
+    Publication.prototype.getData = function() {
         return _.values(this.cache);
-    }
+    };
 }
 }());

--- a/dist/zerv-ng-sync.js
+++ b/dist/zerv-ng-sync.js
@@ -1984,7 +1984,7 @@
                         if (!completed && deferredInitialization === initializationPromise) {
                             logError('Failed to load data within ' + initializationTimeout / 1000 + 's for ' + thisSub);
                             initializationPromise.reject('sync timeout');
-                            // give up syncing.
+                            // give up syncing and release resources.
                             thisSub.syncOff();
                         }
                     }, initializationTimeout);
@@ -2139,10 +2139,10 @@
                 }
 
                 function listenForReconnectionToResync(listenNow) {
-                    // give a chance to connect before listening to reconnection... @TODO should have user_reconnected_event
+                    // give a chance to connect before listening to reconnection.
                     setTimeout(function () {
-                        reconnectOff = innerScope.$on('user_connected', function () {
-                            isLogDebug && logDebug('Resyncing after network loss to ' + publication);
+                        reconnectOff = innerScope.$on('user_reconnected', function () {
+                            isLogDebug && logDebug('Resyncing after network loss to ' + publication + JSON.stringify(thisSub.getParameters()));
                             // note the backend might return a new subscription if the client took too much time to reconnect.
                             registerSubscription();
                         });

--- a/dist/zerv-ng-sync.js
+++ b/dist/zerv-ng-sync.js
@@ -1,14 +1,14 @@
 'use strict';
 
-(function () {
-    "use strict";
+(function() {
+    'use strict';
 
     angular.module('zerv.sync', ['zerv.core']);
 })();
 'use strict';
 
-(function () {
-    "use strict";
+(function() {
+    'use strict';
 
     /**
      * 
@@ -36,11 +36,11 @@
 
     function pgProvider() {
         var bluebird;
-        this.useBluebird = function () {
+        this.useBluebird = function() {
             bluebird = true;
         };
 
-        this.$get = ["$q", function pq($q) {
+        this.$get = ['$q', function pq($q) {
             if (!bluebird || bluebird && Promise && !Promise.bind) {
                 return $q;
             }
@@ -48,7 +48,7 @@
             return {
                 defer: function defer() {
                     var pResolve, pReject;
-                    var p = new Promise(function (resolve, reject) {
+                    var p = new Promise(function(resolve, reject) {
                         pResolve = resolve;
                         pReject = reject;
                     });
@@ -59,7 +59,7 @@
                         reject: function reject(data) {
                             return pReject(data);
                         },
-                        promise: p
+                        promise: p,
                     };
                 },
 
@@ -73,15 +73,15 @@
 
                 all: function all(promises) {
                     return Promise.all(promises);
-                }
+                },
             };
         }];
     }
 })();
 'use strict';
 
-(function () {
-    "use strict";
+(function() {
+    'use strict';
 
     angular.module('zerv.sync').factory('$syncGarbageCollector', syncGarbageCollector);
 
@@ -104,7 +104,7 @@
             dispose: dispose,
             schedule: schedule,
             run: run,
-            getItemCount: getItemCount
+            getItemCount: getItemCount,
         };
 
         return service;
@@ -126,7 +126,7 @@
         function dispose(collect) {
             items.push({
                 timestamp: Date.now(),
-                collect: collect
+                collect: collect,
             });
             if (!scheduled) {
                 service.schedule();
@@ -139,7 +139,7 @@
                 return;
             }
             scheduled = true;
-            setTimeout(function () {
+            setTimeout(function() {
                 service.run();
                 if (items.length > 0) {
                     schedule();
@@ -159,8 +159,8 @@
 })();
 'use strict';
 
-(function () {
-    "use strict";
+(function() {
+    'use strict';
 
     angular.module('zerv.sync').provider('$syncMapping', syncMappingProvider);
 
@@ -188,17 +188,17 @@
     function syncMappingProvider() {
         var isLogDebug;
 
-        this.setDebug = function (value) {
+        this.setDebug = function(value) {
             isLogDebug = value;
         };
 
-        this.$get = ["$pq", function syncMapping($pq) {
+        this.$get = ['$pq', function syncMapping($pq) {
             var service = {
                 addSyncObjectDefinition: addSyncObjectDefinition,
                 addSyncArrayDefinition: addSyncArrayDefinition,
                 mapObjectPropertiesToSubscriptionData: mapObjectPropertiesToSubscriptionData,
                 removePropertyMappers: removePropertyMappers,
-                destroyDependentSubscriptions: destroyDependentSubscriptions
+                destroyDependentSubscriptions: destroyDependentSubscriptions,
             };
 
             return service;
@@ -242,7 +242,7 @@
                     single: true,
                     objectClass: options.objectClass || Object,
                     mappings: options.mappings,
-                    notifyReady: options.notifyReady
+                    notifyReady: options.notifyReady,
                 });
                 return subscription;
             }
@@ -262,7 +262,7 @@
                     single: false,
                     objectClass: options.objectClass || Object,
                     mappings: options.mappings,
-                    notifyReady: options.notifyReady
+                    notifyReady: options.notifyReady,
 
                 });
                 return subscription;
@@ -300,7 +300,7 @@
                     };
                 }
 
-                return function () {
+                return function() {
                     var mappingParams = fn.apply(this, arguments);
                     // if there is no param, there is no mapping to do, most likely, there is no need for the dependent subscription
                     // ex a person.driverLicenceId.... if that person does not have this information, there would be no need to try to subscribe
@@ -326,9 +326,9 @@
                 if (!propertyMappers) {
                     propertyMappers = createPropertyMappers(subscription, obj);
                 }
-                return $pq.all(_.map(propertyMappers, function (propertyMapper) {
+                return $pq.all(_.map(propertyMappers, function(propertyMapper) {
                     return propertyMapper.update(obj);
-                })).then(function () {
+                })).then(function() {
                     // object is now mapped with all data supplied by the subscriptions.
                     return obj;
                 });
@@ -343,12 +343,12 @@
                 isLogDebug && logDebug('Sync -> creating ' + subscription.$dependentSubscriptionDefinitions.length + ' property mapper(s) for record #' + JSON.stringify(obj.id) + ' of subscription ' + subscription);
 
                 var propertyMappers = [];
-                _.forEach(subscription.$dependentSubscriptionDefinitions, function (dependentSubDef) {
+                _.forEach(subscription.$dependentSubscriptionDefinitions, function(dependentSubDef) {
                     propertyMappers.push(new PropertyMapper(subscription, obj, dependentSubDef));
                 });
                 subscription.$datasources.push({
                     objId: obj.id,
-                    propertyMappers: propertyMappers
+                    propertyMappers: propertyMappers,
                 });
                 return propertyMappers;
             }
@@ -360,7 +360,7 @@
                   *  @returns all the subscriptions linked to this object
                   */
             function findPropertyMappers(subscription, obj) {
-                var objDs = _.find(subscription.$datasources, { objId: obj.id });
+                var objDs = _.find(subscription.$datasources, {objId: obj.id});
                 return objDs ? objDs.propertyMappers : null;
             }
 
@@ -370,10 +370,10 @@
              *  @param <Object> the object of that was removed
              */
             function removePropertyMappers(subscription, obj) {
-                var objDs = _.find(subscription.$datasources, { objId: obj.id });
+                var objDs = _.find(subscription.$datasources, {objId: obj.id});
                 if (objDs && objDs.propertyMappers.length !== 0) {
                     isLogDebug && logDebug('Sync -> Removing property mappers for record #' + obj.id + ' of subscription to ' + subscription);
-                    _.forEach(objDs.propertyMappers, function (sub) {
+                    _.forEach(objDs.propertyMappers, function(sub) {
                         sub.destroy();
                     });
                 }
@@ -383,13 +383,13 @@
              * Destroy all subscriptions created by a subscription that has property mappers
              */
             function destroyDependentSubscriptions(subscription) {
-                var allSubscriptions = _.flatten(_.map(subscription.$datasources, function (datasource) {
-                    return _.map(datasource.propertyMappers, function (propertyMapper) {
+                var allSubscriptions = _.flatten(_.map(subscription.$datasources, function(datasource) {
+                    return _.map(datasource.propertyMappers, function(propertyMapper) {
                         return propertyMapper.subscription;
                     });
                 }));
                 var deps = [];
-                _.forEach(allSubscriptions, function (sub) {
+                _.forEach(allSubscriptions, function(sub) {
                     if (!sub) {
                         return;
                     }
@@ -436,11 +436,11 @@
                     } else {
                         propertyMapper.setParams(obj, subParams);
 
-                        return propertyMapper.subscription.waitForDataReady().then(function (data) {
+                        return propertyMapper.subscription.waitForDataReady().then(function(data) {
                             if (propertyMapper.subscription.isSingle()) {
                                 propertyMapper.definition.mapFn(data, obj, false, '');
                             } else {
-                                _.forEach(data, function (resultObj) {
+                                _.forEach(data, function(resultObj) {
                                     propertyMapper.definition.mapFn(resultObj, obj, false, '');
                                 });
                             }
@@ -523,7 +523,7 @@
                 var sub = subscription;
                 var params = [];
                 while (sub) {
-                    params.push({ publication: sub.getPublication(), params: sub.getParameters() });
+                    params.push({publication: sub.getPublication(), params: sub.getParameters()});
                     sub = sub.$parentSubscription;
                 }
                 return params;
@@ -534,7 +534,7 @@
              * 
              */
             function findSubScriptionInPool(subscription, definition, params) {
-                var depSub = _.find(subscription.$getPool(), function (subscription) {
+                var depSub = _.find(subscription.$getPool(), function(subscription) {
                     // subscription should have a propertyMapper for the definition
                     return _.isEqual(subscription.getParameters(), params);
                 });
@@ -548,7 +548,7 @@
                *  @returns all the subscriptions linked to this object
                */
             function createObjectDependentSubscription(subscription, definition, subParams) {
-                var depSub = subscription.$createDependentSubscription(definition.publication).setObjectClass(definition.objectClass).setSingle(definition.single).mapData(function (dependentSubObject, operation) {
+                var depSub = subscription.$createDependentSubscription(definition.publication).setObjectClass(definition.objectClass).setSingle(definition.single).mapData(function(dependentSubObject, operation) {
                     // map will be triggered in the following conditions:
                     // - when the first time, the object is received, this dependent sync will be created and call map when it receives its data
                     // - the next time the dependent syncs
@@ -563,10 +563,10 @@
                     // To dig in, mostlikely when the dependent subscription is created, mapFn will be called twice.
                     // Try to prevent this... 
                     // -------------------------------------------------
-                    _.forEach(depSub.propertyMappers, function (propertyMapper) {
+                    _.forEach(depSub.propertyMappers, function(propertyMapper) {
                         propertyMapper.mapFn(dependentSubObject, operation);
                     });
-                }).setOnReady(function () {
+                }).setOnReady(function() {
                     // if the main sync is NOT ready, it means it is in the process of being ready and will notify when it is
                     if (definition.notifyReady && subscription.isReady()) {
                         notifyMainSubscription(subscription, depSub);
@@ -616,8 +616,8 @@
 })();
 'use strict';
 
-(function () {
-    "use strict";
+(function() {
+    'use strict';
 
     /**
      * TEST
@@ -641,7 +641,7 @@
      *
      */
 
-    syncProvider.$inject = ["$syncMappingProvider"];
+    syncProvider.$inject = ['$syncMappingProvider'];
     angular.module('zerv.sync').provider('$sync', syncProvider);
 
     function syncProvider($syncMappingProvider) {
@@ -657,19 +657,19 @@
 
         var latencyInMilliSecs = 0;
 
-        this.setDebug = function (value) {
+        this.setDebug = function(value) {
             isLogInfo = value >= 1;
             isLogDebug = value >= 2;
             isLogTrace = value >= 3;
             $syncMappingProvider.setDebug(isLogDebug);
             return this;
         };
-        this.setBenchmark = function (value) {
+        this.setBenchmark = function(value) {
             benchmark = value;
             return this;
         };
 
-        this.setStrictCode = function (value) {
+        this.setStrictCode = function(value) {
             strictCode = value;
             return this;
         };
@@ -680,7 +680,7 @@
          * @param <number> milliseconds
          *
          */
-        this.setLatency = function (seconds) {
+        this.setLatency = function(seconds) {
             latencyInMilliSecs = seconds;
             return this;
         };
@@ -690,23 +690,23 @@
          *
          *  @param <number> seconds
          */
-        this.setReleaseDelay = function (seconds) {
+        this.setReleaseDelay = function(seconds) {
             defaultReleaseDelay = seconds * 1000;
             return this;
         };
 
-        this.setInitializationTimeout = function (seconds) {
+        this.setInitializationTimeout = function(seconds) {
             defaultInitializationTimeout = seconds * 1000;
             return this;
         };
 
-        this.$get = ["$rootScope", "$pq", "$socketio", "$syncGarbageCollector", "$syncMapping", "sessionUser", function sync($rootScope, $pq, $socketio, $syncGarbageCollector, $syncMapping, sessionUser) {
+        this.$get = ['$rootScope', '$pq', '$socketio', '$syncGarbageCollector', '$syncMapping', 'sessionUser', function sync($rootScope, $pq, $socketio, $syncGarbageCollector, $syncMapping, sessionUser) {
             var publicationListeners = {};
             var lastPublicationListenerUid = 0;
             var GRACE_PERIOD_IN_SECONDS = 8;
             var SYNC_VERSION = '1.4';
 
-            var deserialize = _.isNil(window.ZJSONBIN) || window.ZJSONBIN.disabled ? function (v) {
+            var deserialize = _.isNil(window.ZJSONBIN) || window.ZJSONBIN.disabled ? function(v) {
                 return v;
             } : window.ZJSONBIN.deserialize;
             var differenceBetween = _.get(window.ZJSONBIN, 'differenceBetween');
@@ -722,7 +722,7 @@
                 getIdValue: getIdValue,
                 getCurrentSubscriptionCount: getCurrentSubscriptionCount,
                 differenceBetween: differenceBetween,
-                mergeChanges: mergeChanges
+                mergeChanges: mergeChanges,
             };
 
             return service;
@@ -743,7 +743,7 @@
                 var sDs = subscribe(publicationName).setObjectClass(objectClass);
 
                 // give a little time for subscription to fetch the data...otherwise give up so that we don't get stuck in a resolve waiting forever.
-                var gracePeriod = setTimeout(function () {
+                var gracePeriod = setTimeout(function() {
                     if (!sDs.ready) {
                         sDs.destroy();
                         isLogInfo && logInfo('Attempt to subscribe to publication ' + publicationName + ' failed');
@@ -751,10 +751,10 @@
                     }
                 }, GRACE_PERIOD_IN_SECONDS * 1000);
 
-                sDs.setParameters(params).waitForDataReady().then(function () {
+                sDs.setParameters(params).waitForDataReady().then(function() {
                     clearTimeout(gracePeriod);
                     deferred.resolve(sDs);
-                }).catch(function () {
+                }).catch(function() {
                     clearTimeout(gracePeriod);
                     sDs.destroy();
                     deferred.reject('Failed to subscribe to publication ' + publicationName + ' failed');
@@ -764,7 +764,7 @@
 
             function subscribeObject(schema, id) {
                 var options = _.assign({}, schema.options);
-                return subscribe(schema.publication).setSingle(true).setObjectClass(options.objectClass).map(options.mappings).setParameters({ id: id });
+                return subscribe(schema.publication).setSingle(true).setObjectClass(options.objectClass).map(options.mappings).setParameters({id: id});
             }
 
             /**
@@ -791,7 +791,7 @@
 
             // every sync notification comes thru the same event then it is dispatches to the targeted subscriptions.
             function listenToPublicationNotification() {
-                $socketio.on('SYNC_NOW', function (serializedObj, fn) {
+                $socketio.on('SYNC_NOW', function(serializedObj, fn) {
                     var subNotification = deserialize(serializedObj);
 
                     isLogInfo && logInfo('Syncing with [' + subNotification.name + ', id:' + subNotification.subscriptionId + ' , params:' + JSON.stringify(subNotification.params) + ']. Records:' + subNotification.records.length + '[' + (subNotification.diff ? 'Diff' : 'All') + ']');
@@ -823,7 +823,7 @@
                 //    console.log('Added new one. remaining active publication: ' + totalSub);
 
 
-                return function () {
+                return function() {
                     totalSub--;
                     //    console.log('Release one. remaining active publication: ' + totalSub);
                     delete listeners[uid];
@@ -860,7 +860,7 @@
                 this.setOnReady = onDataReceived;
 
                 // when the subscription data is updated, the subset updates its own cache.
-                var offs = [ds.onUpdate(updateCache), ds.onAdd(updateCache), ds.onRemove(deleteCache), ds.onReady(function () {
+                var offs = [ds.onUpdate(updateCache), ds.onAdd(updateCache), ds.onRemove(deleteCache), ds.onReady(function() {
                     if (orderByFn) {
                         orderByFn();
                     }
@@ -877,9 +877,9 @@
                 * Refresh the data, this could be necessary if the filter is based on external information that has changed
                 */
                 function refresh() {
-                    return ds.getAll().then(function (data) {
+                    return ds.getAll().then(function(data) {
                         cache.length = 0;
-                        _.forEach(data, function (record) {
+                        _.forEach(data, function(record) {
                             return updateCache(record);
                         });
                     });
@@ -905,7 +905,7 @@
                         throw new Error('Filtered dataset is already attached to a scope');
                     }
                     scope = newScope;
-                    scope.$on('$destroy', function () {
+                    scope.$on('$destroy', function() {
                         destroy();
                     });
                     return this;
@@ -927,7 +927,7 @@
 
                 function updateCache(rec) {
                     if (filter(rec, ds.getVars())) {
-                        var i = _.findIndex(cache, { id: rec.id });
+                        var i = _.findIndex(cache, {id: rec.id});
                         if (i !== -1) {
                             cache[i] = rec;
                         } else {
@@ -940,12 +940,12 @@
                 }
 
                 function deleteCache(rec) {
-                    _.remove(cache, { id: rec.id });
+                    _.remove(cache, {id: rec.id});
                 }
 
                 function destroy() {
                     onDestroyFn(this);
-                    _.forEach(offs, function (off) {
+                    _.forEach(offs, function(off) {
                         off();
                     });
                 }
@@ -963,12 +963,12 @@
                 function getOne(args) {
                     if (_.isNil(args)) {
                         // throw new Error('GetOne requires parameters');
-                        return waitForDataReady().then(function () {
+                        return waitForDataReady().then(function() {
                             return null;
                         });
                     }
                     args = _.concat([cache], arguments);
-                    return waitForDataReady().then(function () {
+                    return waitForDataReady().then(function() {
                         return _.find.apply(this, args);
                     });
                 }
@@ -979,7 +979,7 @@
                  *  @returns {Promise} returns with all data
                  */
                 function getAll() {
-                    return waitForDataReady().then(function () {
+                    return waitForDataReady().then(function() {
                         return cache;
                     });
                 }
@@ -996,7 +996,7 @@
                     orderByFn = function orderByFn() {
                         var orderedCache = _.orderBy(cache, fields, orders);
                         cache.length = 0;
-                        _.forEach(orderedCache, function (rec) {
+                        _.forEach(orderedCache, function(rec) {
                             cache.push(rec);
                         });
                     };
@@ -1177,19 +1177,19 @@
 
                 function getVars() {
                     var varObject = {};
-                    _.forEach(globalVars, function (item) {
+                    _.forEach(globalVars, function(item) {
                         varObject[item.name] = item.value;
                     });
                     return varObject;
                 }
 
                 function getVar(name) {
-                    var globalVar = _.find(globalVars, { name: name });
+                    var globalVar = _.find(globalVars, {name: name});
                     return globalVar ? globalVar.value : null;
                 }
 
                 function setVar(name, fetchFn) {
-                    globalVars.push({ name: name, fetchFn: fetchFn });
+                    globalVars.push({name: name, fetchFn: fetchFn});
                     return thisSub;
                 }
 
@@ -1204,13 +1204,13 @@
                         throw new Error('GetOne is only applicable to an array subscription.');
                     }
                     if (_.isNil(args)) {
-                        return waitForDataReady().then(function () {
+                        return waitForDataReady().then(function() {
                             return null;
                         });
                         // throw new Error('GetOne requires parameters');
                     }
                     args = _.concat([getData()], arguments);
-                    return waitForDataReady().then(function () {
+                    return waitForDataReady().then(function() {
                         return _.find.apply(this, args);
                     });
                 }
@@ -1224,7 +1224,7 @@
                     if (isSingle()) {
                         throw new Error('GetOne is only applicable to an array subscription.');
                     }
-                    return waitForDataReady().then(function () {
+                    return waitForDataReady().then(function() {
                         return getData();
                     });
                 }
@@ -1253,7 +1253,7 @@
                         return;
                     }
                     destroyed = true;
-                    _.forEach(filteredDataSets, function (ds) {
+                    _.forEach(filteredDataSets, function(ds) {
                         ds.destroy();
                     });
 
@@ -1268,7 +1268,7 @@
                 }
 
                 function createSubSet(filter, scope) {
-                    var fds = new FilteredSubSet(thisSub, filter, scope, function () {
+                    var fds = new FilteredSubSet(thisSub, filter, scope, function() {
                         _.remove(filteredDataSets, fds);
                     });
                     filteredDataSets.push(fds);
@@ -1281,7 +1281,7 @@
                 * If not all subsets rely on external data for filtering, a refresh method can be called on the subset that does for increased performance.
                 */
                 function refreshSubSets() {
-                    return $pq.all(_.map(filteredDataSets, function (subSet) {
+                    return $pq.all(_.map(filteredDataSets, function(subSet) {
                         return subSet.refresh();
                     }));
                 }
@@ -1491,20 +1491,20 @@
 
                 function mapExternalSubscriptionToProperty(propertyName, fetchFn, idProperty) {
                     dependentSubscriptions.push(fetchFn);
-                    mapPropertyFns.push(function (obj) {
+                    mapPropertyFns.push(function(obj) {
                         if (typeof obj[idProperty] === 'undefined') {
                             throw new Error('Undefined property ' + idProperty + ' of data received from subscription to ' + publication);
                         }
                         var fetchParams = {};
                         fetchParams.id = obj[idProperty];
-                        return fetchFn.setParameters(fetchParams).waitForDataReady().then(function (object) {
+                        return fetchFn.setParameters(fetchParams).waitForDataReady().then(function(object) {
                             obj[propertyName] = object;
                         });
                     });
                 }
 
                 function mapPromisedDataToProperty(propertyName, fetchFn, idProperty) {
-                    mapPropertyFns.push(function (obj) {
+                    mapPropertyFns.push(function(obj) {
                         var dot = propertyName.indexOf('.');
                         if (dot !== -1) {
                             var arrayName = propertyName.substring(0, dot);
@@ -1522,7 +1522,7 @@
                                 return fetchAndSet(obj, idProperty, itemPropertyName);
                             }
 
-                            return $pq.all(_.map(obj[arrayName], function (item) {
+                            return $pq.all(_.map(obj[arrayName], function(item) {
                                 if (typeof item[idProperty] === 'undefined') {
                                     throw new Error('Undefined property ' + idProperty + ' in array ' + propertyName + ' of data received from subscription to ' + publication);
                                 }
@@ -1539,9 +1539,9 @@
                     function fetchAndSet(obj, idProperty, propertyName) {
                         var result = fetchFn(obj[idProperty]);
                         if (result && result.then) {
-                            return result.then(function (value) {
+                            return result.then(function(value) {
                                 obj[propertyName] = value;
-                            }, function (err) {
+                            }, function(err) {
                                 throw new Error('Fetching error for property mapping ' + idProperty + ' in data received from subscription to ' + publication + '. err: ' + err);
                             });
                         }
@@ -1640,15 +1640,15 @@
                  * @returns <Promise> returns a promise that is resolved when the object is completely mapped
                  */
                 function mapAllDataToObject(obj, operation) {
-                    return $pq.all(_.map(globalVars, function (varObj) {
-                        return varObj.fetchFn().then(function (data) {
+                    return $pq.all(_.map(globalVars, function(varObj) {
+                        return varObj.fetchFn().then(function(data) {
                             varObj.value = data;
                         });
-                    })).then(function () {
-                        return $syncMapping.mapObjectPropertiesToSubscriptionData(thisSub, obj).then(function (obj) {
+                    })).then(function() {
+                        return $syncMapping.mapObjectPropertiesToSubscriptionData(thisSub, obj).then(function(obj) {
                             // , operation) {
                             return mapFullObject(obj, operation);
-                        }).catch(function (err) {
+                        }).catch(function(err) {
                             logError('Error when mapping received object.', err);
                             $pq.reject(err);
                         });
@@ -1668,11 +1668,11 @@
                   *
                  */
                 function mapFullObject(obj, operation) {
-                    return mapAllRecordProperties(obj, operation).then(function () {
+                    return mapAllRecordProperties(obj, operation).then(function() {
                         if (mapCustomDataFn) {
                             var result = mapCustomDataFn(obj, operation, getVars());
                             if (result && result.then) {
-                                return result.then(function () {
+                                return result.then(function() {
                                     return obj;
                                 });
                             }
@@ -1694,7 +1694,7 @@
                  * @param {*} operation
                  */
                 function mapAllRecordProperties(obj, operation) {
-                    return $pq.all(_.map(mapPropertyFns, function (mapPropertyFn) {
+                    return $pq.all(_.map(mapPropertyFns, function(mapPropertyFn) {
                         // property mapping does not need to clear the property mapping when cache is cleaned.
                         // -> means mapData will no be called in case on cache cleaning.
                         // this is not a problem except if the developer uses mapData function for other thing that mapping data.
@@ -1708,7 +1708,7 @@
                         try {
                             var result = mapPropertyFn(obj, operation);
                             if (result && result.then) {
-                                return result.then(function () {
+                                return result.then(function() {
                                     return obj;
                                 });
                             }
@@ -1726,7 +1726,7 @@
                 }
 
                 function $notifyUpdateWithinDependentSubscription(idOfObjectImpactedByChange) {
-                    var cachedObject = getRecordState({ id: idOfObjectImpactedByChange });
+                    var cachedObject = getRecordState({id: idOfObjectImpactedByChange});
                     syncListener.notify('ready', getData(), [cachedObject], true);
                 }
 
@@ -1782,7 +1782,7 @@
                  * @returns {Promise} that waits for the initial fetch to complete then wait for the initial fetch to complete then returns this subscription.
                  */
                 function waitForSubscriptionReady(callback) {
-                    return startSyncing().then(function () {
+                    return startSyncing().then(function() {
                         if (callback) {
                             callback(thisSub);
                         }
@@ -1797,7 +1797,7 @@
                  * @returns {Promise} that waits for the initial fetch to complete then returns the data
                  */
                 function waitForDataReady(callback) {
-                    return startSyncing().then(function (data) {
+                    return startSyncing().then(function(data) {
                         if (callback) {
                             callback(data, thisSub);
                         }
@@ -1818,7 +1818,7 @@
                         cache = ObjectClass ? clearObject(new ObjectClass({})) : {};
                         cache.timestamp = {
                             $empty: true,
-                            $sync: thisSub
+                            $sync: thisSub,
                         };
                     } else {
                         updateFn = updateSyncedArray;
@@ -1873,7 +1873,7 @@
                     if (isSingleObjectCache) {
                         return cache.id === id ? cache : null;
                     }
-                    return _.find(cache, { id: id });
+                    return _.find(cache, {id: id});
                 }
 
                 /**
@@ -1952,7 +1952,7 @@
                         // better solution would be that the external subscription let know this subscription that is params has been modified, then only we would refresh
                         // the mapping.
                         if (dependentSubscriptions.length) {
-                            deferredInitialization.promise.then(function (data) {
+                            deferredInitialization.promise.then(function(data) {
                                 refreshMapping(getData());
                             });
                         }
@@ -1980,7 +1980,7 @@
                     }
                     var initializationPromise = deferredInitialization;
                     var completed = false;
-                    setTimeout(function () {
+                    setTimeout(function() {
                         if (!completed && deferredInitialization === initializationPromise) {
                             logError('Failed to load data within ' + initializationTimeout / 1000 + 's for ' + thisSub);
                             initializationPromise.reject('sync timeout');
@@ -1988,7 +1988,7 @@
                             thisSub.syncOff();
                         }
                     }, initializationTimeout);
-                    initializationPromise.promise.then(function () {
+                    initializationPromise.promise.then(function() {
                         completed = true;
                     });
                 }
@@ -2000,11 +2000,11 @@
                             listenForReconnectionToResync();
                         }
 
-                        publicationListenerOff = addPublicationListener(publication, function (batch) {
+                        publicationListenerOff = addPublicationListener(publication, function(batch) {
                             // Create a delay before processing publication data to simulate network latency
                             if (latencyInMilliSecs) {
                                 isLogInfo && logInfo('Sync -> Processing delayed for ' + latencyInMilliSecs + ' ms.'); //
-                                setTimeout(function () {
+                                setTimeout(function() {
                                     isLogInfo && logInfo('Sync -> Processing ' + publication + ' now.');
                                     processPublicationData(batch);
                                 }, latencyInMilliSecs);
@@ -2052,7 +2052,7 @@
                         isLogDebug && logDebug('Release not necessary (unattached): ' + thisSub);
                     } else {
                         isLogDebug && logDebug('Releasing subscription in ' + releaseDelay / 1000 + 's: ' + thisSub);
-                        releaseTimeout = setTimeout(function () {
+                        releaseTimeout = setTimeout(function() {
                             if (releaseTimeout) {
                                 isLogInfo && logInfo('Subscription released: ' + thisSub);
                                 thisSub.syncOff();
@@ -2079,7 +2079,7 @@
                         destroyOff();
                     }
                     innerScope = $rootScope;
-                    _.forEach(dependentSubscriptions, function (dsub) {
+                    _.forEach(dependentSubscriptions, function(dsub) {
                         dsub.detach();
                     });
                 }
@@ -2123,7 +2123,7 @@
                     innerScope = newScope;
                     var destroyScope = innerScope; // memorize scope as it is used during destroy
 
-                    destroyOff = innerScope.$on('$destroy', function () {
+                    destroyOff = innerScope.$on('$destroy', function() {
                         syncListener.dropListeners(destroyScope);
                         if (delayRelease) {
                             scheduleRelease();
@@ -2132,7 +2132,7 @@
                         }
                     });
 
-                    _.forEach(dependentSubscriptions, function (dsub) {
+                    _.forEach(dependentSubscriptions, function(dsub) {
                         dsub.attach(newScope, delayRelease);
                     });
                     return thisSub;
@@ -2140,8 +2140,8 @@
 
                 function listenForReconnectionToResync(listenNow) {
                     // give a chance to connect before listening to reconnection.
-                    setTimeout(function () {
-                        reconnectOff = innerScope.$on('user_reconnected', function () {
+                    setTimeout(function() {
+                        reconnectOff = innerScope.$on('user_reconnected', function() {
                             isLogDebug && logDebug('Resyncing after network loss to ' + publication + JSON.stringify(thisSub.getParameters()));
                             // note the backend might return a new subscription if the client took too much time to reconnect.
                             registerSubscription();
@@ -2162,8 +2162,8 @@
                         version: SYNC_VERSION,
                         id: subscriptionId, // to try to re-use existing subcription
                         publication: publication,
-                        params: subParams
-                    }).then(function (subId) {
+                        params: subParams,
+                    }).then(function(subId) {
                         // registration might complete after an order to syncOff.
                         if (isSyncingOn) {
                             // syncing is on, let's remember the subId for potential reconnect to prevent refetching all data.
@@ -2179,7 +2179,7 @@
                             id: subscriptionId,
                             // following only useful for unit testing
                             publication: publication,
-                            params: subParams
+                            params: subParams,
                         });
                         subscriptionId = null;
                     }
@@ -2235,9 +2235,9 @@
                         var dataReceivedIn = Date.now() - initialStartTime;
                         var size = benchmark && isLogInfo ? JSON.stringify(batch.records).length : null;
 
-                        return cleanCache(batch.records, !batch.diff).then(function () {
+                        return cleanCache(batch.records, !batch.diff).then(function() {
                             return applyChanges(batch.records, false);
-                        }).then(function () {
+                        }).then(function() {
                             if (!isInitialPushCompleted) {
                                 isInitialPushCompleted = true;
 
@@ -2291,7 +2291,7 @@
                     } else {
                         result = cleanObjectCache();
                     }
-                    return result.catch(function (err) {
+                    return result.catch(function(err) {
                         logError('Error clearing subscription cache - ' + err);
                     });
                 }
@@ -2306,8 +2306,8 @@
                  */
                 function findRecordsPresentInCacheOnly(receivedRecordsToBeSynced) {
                     var deletedRecords = [];
-                    _.forEach(recordStates, function (cachedRecord, id) {
-                        if (!_.find(receivedRecordsToBeSynced, function (record) {
+                    _.forEach(recordStates, function(cachedRecord, id) {
+                        if (!_.find(receivedRecordsToBeSynced, function(record) {
                             return id === getIdValue(record.id);
                         })) {
                             deletedRecords.push(cachedRecord);
@@ -2324,13 +2324,13 @@
                  */
                 function cleanArrayCache(records) {
                     var promises = [];
-                    _.forEach(records, function (obj) {
+                    _.forEach(records, function(obj) {
                         $syncMapping.removePropertyMappers(thisSub, obj);
                         obj.removed = true;
                         promises.push(mapFullObject(obj, 'clear'));
                         delete recordStates[getIdValue(obj.id)];
                     });
-                    return $pq.all(promises).catch(function (err) {
+                    return $pq.all(promises).catch(function(err) {
                         logError('Error clearing subscription cache - ' + err);
                     });
                 }
@@ -2381,7 +2381,7 @@
                         if (!isSingle()) {
                             var orderedCache = _.orderBy(cache, fields, orders);
                             cache.length = 0;
-                            _.forEach(orderedCache, function (rec) {
+                            _.forEach(orderedCache, function(rec) {
                                 cache.push(rec);
                             });
                         }
@@ -2427,27 +2427,27 @@
                  */
                 function applyChanges(records, force) {
                     thisSub.ready = false;
-                    return waitForExternalDatasourcesReady().then(function () {
+                    return waitForExternalDatasourcesReady().then(function() {
                         try {
                             var newDataArray = [];
                             var promises = [];
-                            records.forEach(function (record) {
+                            records.forEach(function(record) {
                                 //                   isInfo && logInfo('Datasync [' + dataStreamName + '] received:' +JSON.stringify(record));//+ JSON.stringify(record.id));
                                 if (record.remove) {
                                     promises.push(removeRecord(record, force));
                                 } else if (getRecordState(record)) {
                                     // if the record is already present in the cache...so it is mightbe an update..
-                                    promises.push(updateRecord(record, force).then(function (newData) {
+                                    promises.push(updateRecord(record, force).then(function(newData) {
                                         newDataArray.push(newData);
                                     }));
                                 } else {
                                     // if the record is already present in the cache...so it is mightbe an update..
-                                    promises.push(addRecord(record, force).then(function (newData) {
+                                    promises.push(addRecord(record, force).then(function(newData) {
                                         newDataArray.push(newData);
                                     }));
                                 }
                             });
-                            return $pq.all(promises).then(function () {
+                            return $pq.all(promises).then(function() {
                                 // if order alterered, re-order
                                 if (newDataArray.length && orderByFn) {
                                     orderByFn();
@@ -2467,7 +2467,7 @@
                     return {
                         then: function then(cb) {
                             return cb();
-                        }
+                        },
                     }; // $pq.resolve();
                 }
 
@@ -2546,7 +2546,7 @@
 
                     var obj = formatRecord ? formatRecord(record) : record;
 
-                    return mapAllDataToObject(obj, 'add').then(function () {
+                    return mapAllDataToObject(obj, 'add').then(function() {
                         obj = updateDataStorage(obj, force);
                         syncListener.notify('add', obj);
                         return obj;
@@ -2585,7 +2585,7 @@
                     isLogDebug && logDebug('Sync -> Updated record #' + JSON.stringify(record.id) + (force ? ' directly' : ' via sync') + ' for subscription to ' + thisSub);
                     obj = formatRecord ? formatRecord(record) : record;
 
-                    return mapAllDataToObject(obj, 'update').then(function () {
+                    return mapAllDataToObject(obj, 'update').then(function() {
                         obj = updateDataStorage(obj, force);
                         syncListener.notify('update', obj);
                         return obj;
@@ -2663,7 +2663,7 @@
                         merge(cache, record);
                     } else {
                         clearObject(cache);
-                        cache.timestamp = { $empty: true };
+                        cache.timestamp = {$empty: true};
                     }
                     return cache;
                 }
@@ -2701,7 +2701,7 @@
                 }
 
                 function clearObject(object) {
-                    Object.keys(object).forEach(function (key) {
+                    Object.keys(object).forEach(function(key) {
                         delete object[key];
                     });
                     return object;
@@ -2731,8 +2731,8 @@
                 this.dropListeners = dropListeners;
 
                 function dropListeners(scope) {
-                    _.forEach(events, function (listeners) {
-                        _.forEach(listeners, function (listener, id) {
+                    _.forEach(events, function(listeners) {
+                        _.forEach(listeners, function(listener, id) {
                             if (listener.scope === scope) {
                                 delete listeners[id];
                             }
@@ -2752,7 +2752,7 @@
                         logTime(subDef);
                     }
                     if (listeners) {
-                        _.forEach(listeners, function (listener, id) {
+                        _.forEach(listeners, function(listener, id) {
                             listener.notify(data1, data2);
                         });
                     }
@@ -2772,9 +2772,9 @@
                     var id = count++;
                     listeners[id] = {
                         notify: callback,
-                        scope: scope
+                        scope: scope,
                     };
-                    return function () {
+                    return function() {
                         delete listeners[id];
                     };
                 }
@@ -2786,7 +2786,7 @@
                 return id;
             }
             // build composite key value
-            var r = _.join(_.map(id, function (value) {
+            var r = _.join(_.map(id, function(value) {
                 return value;
             }), '~');
             return r;

--- a/dist/zerv-ng-sync.js
+++ b/dist/zerv-ng-sync.js
@@ -1,14 +1,14 @@
 'use strict';
 
-(function() {
-    'use strict';
+(function () {
+    "use strict";
 
     angular.module('zerv.sync', ['zerv.core']);
 })();
 'use strict';
 
-(function() {
-    'use strict';
+(function () {
+    "use strict";
 
     /**
      * 
@@ -36,11 +36,11 @@
 
     function pgProvider() {
         var bluebird;
-        this.useBluebird = function() {
+        this.useBluebird = function () {
             bluebird = true;
         };
 
-        this.$get = ['$q', function pq($q) {
+        this.$get = ["$q", function pq($q) {
             if (!bluebird || bluebird && Promise && !Promise.bind) {
                 return $q;
             }
@@ -48,7 +48,7 @@
             return {
                 defer: function defer() {
                     var pResolve, pReject;
-                    var p = new Promise(function(resolve, reject) {
+                    var p = new Promise(function (resolve, reject) {
                         pResolve = resolve;
                         pReject = reject;
                     });
@@ -59,7 +59,7 @@
                         reject: function reject(data) {
                             return pReject(data);
                         },
-                        promise: p,
+                        promise: p
                     };
                 },
 
@@ -73,15 +73,15 @@
 
                 all: function all(promises) {
                     return Promise.all(promises);
-                },
+                }
             };
         }];
     }
 })();
 'use strict';
 
-(function() {
-    'use strict';
+(function () {
+    "use strict";
 
     angular.module('zerv.sync').factory('$syncGarbageCollector', syncGarbageCollector);
 
@@ -104,7 +104,7 @@
             dispose: dispose,
             schedule: schedule,
             run: run,
-            getItemCount: getItemCount,
+            getItemCount: getItemCount
         };
 
         return service;
@@ -126,7 +126,7 @@
         function dispose(collect) {
             items.push({
                 timestamp: Date.now(),
-                collect: collect,
+                collect: collect
             });
             if (!scheduled) {
                 service.schedule();
@@ -139,7 +139,7 @@
                 return;
             }
             scheduled = true;
-            setTimeout(function() {
+            setTimeout(function () {
                 service.run();
                 if (items.length > 0) {
                     schedule();
@@ -159,8 +159,8 @@
 })();
 'use strict';
 
-(function() {
-    'use strict';
+(function () {
+    "use strict";
 
     angular.module('zerv.sync').provider('$syncMapping', syncMappingProvider);
 
@@ -188,17 +188,17 @@
     function syncMappingProvider() {
         var isLogDebug;
 
-        this.setDebug = function(value) {
+        this.setDebug = function (value) {
             isLogDebug = value;
         };
 
-        this.$get = ['$pq', function syncMapping($pq) {
+        this.$get = ["$pq", function syncMapping($pq) {
             var service = {
                 addSyncObjectDefinition: addSyncObjectDefinition,
                 addSyncArrayDefinition: addSyncArrayDefinition,
                 mapObjectPropertiesToSubscriptionData: mapObjectPropertiesToSubscriptionData,
                 removePropertyMappers: removePropertyMappers,
-                destroyDependentSubscriptions: destroyDependentSubscriptions,
+                destroyDependentSubscriptions: destroyDependentSubscriptions
             };
 
             return service;
@@ -242,7 +242,7 @@
                     single: true,
                     objectClass: options.objectClass || Object,
                     mappings: options.mappings,
-                    notifyReady: options.notifyReady,
+                    notifyReady: options.notifyReady
                 });
                 return subscription;
             }
@@ -262,7 +262,7 @@
                     single: false,
                     objectClass: options.objectClass || Object,
                     mappings: options.mappings,
-                    notifyReady: options.notifyReady,
+                    notifyReady: options.notifyReady
 
                 });
                 return subscription;
@@ -300,7 +300,7 @@
                     };
                 }
 
-                return function() {
+                return function () {
                     var mappingParams = fn.apply(this, arguments);
                     // if there is no param, there is no mapping to do, most likely, there is no need for the dependent subscription
                     // ex a person.driverLicenceId.... if that person does not have this information, there would be no need to try to subscribe
@@ -326,9 +326,9 @@
                 if (!propertyMappers) {
                     propertyMappers = createPropertyMappers(subscription, obj);
                 }
-                return $pq.all(_.map(propertyMappers, function(propertyMapper) {
+                return $pq.all(_.map(propertyMappers, function (propertyMapper) {
                     return propertyMapper.update(obj);
-                })).then(function() {
+                })).then(function () {
                     // object is now mapped with all data supplied by the subscriptions.
                     return obj;
                 });
@@ -343,12 +343,12 @@
                 isLogDebug && logDebug('Sync -> creating ' + subscription.$dependentSubscriptionDefinitions.length + ' property mapper(s) for record #' + JSON.stringify(obj.id) + ' of subscription ' + subscription);
 
                 var propertyMappers = [];
-                _.forEach(subscription.$dependentSubscriptionDefinitions, function(dependentSubDef) {
+                _.forEach(subscription.$dependentSubscriptionDefinitions, function (dependentSubDef) {
                     propertyMappers.push(new PropertyMapper(subscription, obj, dependentSubDef));
                 });
                 subscription.$datasources.push({
                     objId: obj.id,
-                    propertyMappers: propertyMappers,
+                    propertyMappers: propertyMappers
                 });
                 return propertyMappers;
             }
@@ -360,7 +360,7 @@
                   *  @returns all the subscriptions linked to this object
                   */
             function findPropertyMappers(subscription, obj) {
-                var objDs = _.find(subscription.$datasources, {objId: obj.id});
+                var objDs = _.find(subscription.$datasources, { objId: obj.id });
                 return objDs ? objDs.propertyMappers : null;
             }
 
@@ -370,10 +370,10 @@
              *  @param <Object> the object of that was removed
              */
             function removePropertyMappers(subscription, obj) {
-                var objDs = _.find(subscription.$datasources, {objId: obj.id});
+                var objDs = _.find(subscription.$datasources, { objId: obj.id });
                 if (objDs && objDs.propertyMappers.length !== 0) {
                     isLogDebug && logDebug('Sync -> Removing property mappers for record #' + obj.id + ' of subscription to ' + subscription);
-                    _.forEach(objDs.propertyMappers, function(sub) {
+                    _.forEach(objDs.propertyMappers, function (sub) {
                         sub.destroy();
                     });
                 }
@@ -383,13 +383,13 @@
              * Destroy all subscriptions created by a subscription that has property mappers
              */
             function destroyDependentSubscriptions(subscription) {
-                var allSubscriptions = _.flatten(_.map(subscription.$datasources, function(datasource) {
-                    return _.map(datasource.propertyMappers, function(propertyMapper) {
+                var allSubscriptions = _.flatten(_.map(subscription.$datasources, function (datasource) {
+                    return _.map(datasource.propertyMappers, function (propertyMapper) {
                         return propertyMapper.subscription;
                     });
                 }));
                 var deps = [];
-                _.forEach(allSubscriptions, function(sub) {
+                _.forEach(allSubscriptions, function (sub) {
                     if (!sub) {
                         return;
                     }
@@ -436,11 +436,11 @@
                     } else {
                         propertyMapper.setParams(obj, subParams);
 
-                        return propertyMapper.subscription.waitForDataReady().then(function(data) {
+                        return propertyMapper.subscription.waitForDataReady().then(function (data) {
                             if (propertyMapper.subscription.isSingle()) {
                                 propertyMapper.definition.mapFn(data, obj, false, '');
                             } else {
-                                _.forEach(data, function(resultObj) {
+                                _.forEach(data, function (resultObj) {
                                     propertyMapper.definition.mapFn(resultObj, obj, false, '');
                                 });
                             }
@@ -523,7 +523,7 @@
                 var sub = subscription;
                 var params = [];
                 while (sub) {
-                    params.push({publication: sub.getPublication(), params: sub.getParameters()});
+                    params.push({ publication: sub.getPublication(), params: sub.getParameters() });
                     sub = sub.$parentSubscription;
                 }
                 return params;
@@ -534,7 +534,7 @@
              * 
              */
             function findSubScriptionInPool(subscription, definition, params) {
-                var depSub = _.find(subscription.$getPool(), function(subscription) {
+                var depSub = _.find(subscription.$getPool(), function (subscription) {
                     // subscription should have a propertyMapper for the definition
                     return _.isEqual(subscription.getParameters(), params);
                 });
@@ -548,7 +548,7 @@
                *  @returns all the subscriptions linked to this object
                */
             function createObjectDependentSubscription(subscription, definition, subParams) {
-                var depSub = subscription.$createDependentSubscription(definition.publication).setObjectClass(definition.objectClass).setSingle(definition.single).mapData(function(dependentSubObject, operation) {
+                var depSub = subscription.$createDependentSubscription(definition.publication).setObjectClass(definition.objectClass).setSingle(definition.single).mapData(function (dependentSubObject, operation) {
                     // map will be triggered in the following conditions:
                     // - when the first time, the object is received, this dependent sync will be created and call map when it receives its data
                     // - the next time the dependent syncs
@@ -563,10 +563,10 @@
                     // To dig in, mostlikely when the dependent subscription is created, mapFn will be called twice.
                     // Try to prevent this... 
                     // -------------------------------------------------
-                    _.forEach(depSub.propertyMappers, function(propertyMapper) {
+                    _.forEach(depSub.propertyMappers, function (propertyMapper) {
                         propertyMapper.mapFn(dependentSubObject, operation);
                     });
-                }).setOnReady(function() {
+                }).setOnReady(function () {
                     // if the main sync is NOT ready, it means it is in the process of being ready and will notify when it is
                     if (definition.notifyReady && subscription.isReady()) {
                         notifyMainSubscription(subscription, depSub);
@@ -616,8 +616,8 @@
 })();
 'use strict';
 
-(function() {
-    'use strict';
+(function () {
+    "use strict";
 
     /**
      * TEST
@@ -641,7 +641,7 @@
      *
      */
 
-    syncProvider.$inject = ['$syncMappingProvider'];
+    syncProvider.$inject = ["$syncMappingProvider"];
     angular.module('zerv.sync').provider('$sync', syncProvider);
 
     function syncProvider($syncMappingProvider) {
@@ -651,23 +651,25 @@
         var benchmark = true,
             isLogDebug = void 0,
             isLogInfo = void 0,
+            isLogTrace = void 0,
             defaultReleaseDelay = 30,
             defaultInitializationTimeout = 10;
 
         var latencyInMilliSecs = 0;
 
-        this.setDebug = function(value) {
+        this.setDebug = function (value) {
             isLogInfo = value >= 1;
-            isLogDebug = value === 2;
+            isLogDebug = value >= 2;
+            isLogTrace = value >= 3;
             $syncMappingProvider.setDebug(isLogDebug);
             return this;
         };
-        this.setBenchmark = function(value) {
+        this.setBenchmark = function (value) {
             benchmark = value;
             return this;
         };
 
-        this.setStrictCode = function(value) {
+        this.setStrictCode = function (value) {
             strictCode = value;
             return this;
         };
@@ -678,7 +680,7 @@
          * @param <number> milliseconds
          *
          */
-        this.setLatency = function(seconds) {
+        this.setLatency = function (seconds) {
             latencyInMilliSecs = seconds;
             return this;
         };
@@ -688,23 +690,23 @@
          *
          *  @param <number> seconds
          */
-        this.setReleaseDelay = function(seconds) {
+        this.setReleaseDelay = function (seconds) {
             defaultReleaseDelay = seconds * 1000;
             return this;
         };
 
-        this.setInitializationTimeout = function(seconds) {
+        this.setInitializationTimeout = function (seconds) {
             defaultInitializationTimeout = seconds * 1000;
             return this;
         };
 
-        this.$get = ['$rootScope', '$pq', '$socketio', '$syncGarbageCollector', '$syncMapping', 'sessionUser', function sync($rootScope, $pq, $socketio, $syncGarbageCollector, $syncMapping, sessionUser) {
+        this.$get = ["$rootScope", "$pq", "$socketio", "$syncGarbageCollector", "$syncMapping", "sessionUser", function sync($rootScope, $pq, $socketio, $syncGarbageCollector, $syncMapping, sessionUser) {
             var publicationListeners = {};
             var lastPublicationListenerUid = 0;
             var GRACE_PERIOD_IN_SECONDS = 8;
             var SYNC_VERSION = '1.4';
 
-            var deserialize = _.isNil(window.ZJSONBIN) || window.ZJSONBIN.disabled ? function(v) {
+            var deserialize = _.isNil(window.ZJSONBIN) || window.ZJSONBIN.disabled ? function (v) {
                 return v;
             } : window.ZJSONBIN.deserialize;
             var differenceBetween = _.get(window.ZJSONBIN, 'differenceBetween');
@@ -720,7 +722,7 @@
                 getIdValue: getIdValue,
                 getCurrentSubscriptionCount: getCurrentSubscriptionCount,
                 differenceBetween: differenceBetween,
-                mergeChanges: mergeChanges,
+                mergeChanges: mergeChanges
             };
 
             return service;
@@ -741,7 +743,7 @@
                 var sDs = subscribe(publicationName).setObjectClass(objectClass);
 
                 // give a little time for subscription to fetch the data...otherwise give up so that we don't get stuck in a resolve waiting forever.
-                var gracePeriod = setTimeout(function() {
+                var gracePeriod = setTimeout(function () {
                     if (!sDs.ready) {
                         sDs.destroy();
                         isLogInfo && logInfo('Attempt to subscribe to publication ' + publicationName + ' failed');
@@ -749,10 +751,10 @@
                     }
                 }, GRACE_PERIOD_IN_SECONDS * 1000);
 
-                sDs.setParameters(params).waitForDataReady().then(function() {
+                sDs.setParameters(params).waitForDataReady().then(function () {
                     clearTimeout(gracePeriod);
                     deferred.resolve(sDs);
-                }).catch(function() {
+                }).catch(function () {
                     clearTimeout(gracePeriod);
                     sDs.destroy();
                     deferred.reject('Failed to subscribe to publication ' + publicationName + ' failed');
@@ -762,7 +764,7 @@
 
             function subscribeObject(schema, id) {
                 var options = _.assign({}, schema.options);
-                return subscribe(schema.publication).setSingle(true).setObjectClass(options.objectClass).map(options.mappings).setParameters({id: id});
+                return subscribe(schema.publication).setSingle(true).setObjectClass(options.objectClass).map(options.mappings).setParameters({ id: id });
             }
 
             /**
@@ -789,7 +791,7 @@
 
             // every sync notification comes thru the same event then it is dispatches to the targeted subscriptions.
             function listenToPublicationNotification() {
-                $socketio.on('SYNC_NOW', function(serializedObj, fn) {
+                $socketio.on('SYNC_NOW', function (serializedObj, fn) {
                     var subNotification = deserialize(serializedObj);
 
                     isLogInfo && logInfo('Syncing with [' + subNotification.name + ', id:' + subNotification.subscriptionId + ' , params:' + JSON.stringify(subNotification.params) + ']. Records:' + subNotification.records.length + '[' + (subNotification.diff ? 'Diff' : 'All') + ']');
@@ -821,7 +823,7 @@
                 //    console.log('Added new one. remaining active publication: ' + totalSub);
 
 
-                return function() {
+                return function () {
                     totalSub--;
                     //    console.log('Release one. remaining active publication: ' + totalSub);
                     delete listeners[uid];
@@ -858,7 +860,7 @@
                 this.setOnReady = onDataReceived;
 
                 // when the subscription data is updated, the subset updates its own cache.
-                var offs = [ds.onUpdate(updateCache), ds.onAdd(updateCache), ds.onRemove(deleteCache), ds.onReady(function() {
+                var offs = [ds.onUpdate(updateCache), ds.onAdd(updateCache), ds.onRemove(deleteCache), ds.onReady(function () {
                     if (orderByFn) {
                         orderByFn();
                     }
@@ -875,9 +877,9 @@
                 * Refresh the data, this could be necessary if the filter is based on external information that has changed
                 */
                 function refresh() {
-                    return ds.getAll().then(function(data) {
+                    return ds.getAll().then(function (data) {
                         cache.length = 0;
-                        _.forEach(data, function(record) {
+                        _.forEach(data, function (record) {
                             return updateCache(record);
                         });
                     });
@@ -903,7 +905,7 @@
                         throw new Error('Filtered dataset is already attached to a scope');
                     }
                     scope = newScope;
-                    scope.$on('$destroy', function() {
+                    scope.$on('$destroy', function () {
                         destroy();
                     });
                     return this;
@@ -925,7 +927,7 @@
 
                 function updateCache(rec) {
                     if (filter(rec, ds.getVars())) {
-                        var i = _.findIndex(cache, {id: rec.id});
+                        var i = _.findIndex(cache, { id: rec.id });
                         if (i !== -1) {
                             cache[i] = rec;
                         } else {
@@ -938,12 +940,12 @@
                 }
 
                 function deleteCache(rec) {
-                    _.remove(cache, {id: rec.id});
+                    _.remove(cache, { id: rec.id });
                 }
 
                 function destroy() {
                     onDestroyFn(this);
-                    _.forEach(offs, function(off) {
+                    _.forEach(offs, function (off) {
                         off();
                     });
                 }
@@ -961,12 +963,12 @@
                 function getOne(args) {
                     if (_.isNil(args)) {
                         // throw new Error('GetOne requires parameters');
-                        return waitForDataReady().then(function() {
+                        return waitForDataReady().then(function () {
                             return null;
                         });
                     }
                     args = _.concat([cache], arguments);
-                    return waitForDataReady().then(function() {
+                    return waitForDataReady().then(function () {
                         return _.find.apply(this, args);
                     });
                 }
@@ -977,7 +979,7 @@
                  *  @returns {Promise} returns with all data
                  */
                 function getAll() {
-                    return waitForDataReady().then(function() {
+                    return waitForDataReady().then(function () {
                         return cache;
                     });
                 }
@@ -994,7 +996,7 @@
                     orderByFn = function orderByFn() {
                         var orderedCache = _.orderBy(cache, fields, orders);
                         cache.length = 0;
-                        _.forEach(orderedCache, function(rec) {
+                        _.forEach(orderedCache, function (rec) {
                             cache.push(rec);
                         });
                     };
@@ -1071,7 +1073,7 @@
                 var subParams = {};
                 var recordStates = {};
                 var innerScope = void 0; // = $rootScope.$new(true);
-                var syncListener = new SyncListener();
+                var syncListener = new SyncListener(thisSub);
 
                 var dependentSubscriptions = [];
                 var releaseDelay = defaultReleaseDelay;
@@ -1175,19 +1177,19 @@
 
                 function getVars() {
                     var varObject = {};
-                    _.forEach(globalVars, function(item) {
+                    _.forEach(globalVars, function (item) {
                         varObject[item.name] = item.value;
                     });
                     return varObject;
                 }
 
                 function getVar(name) {
-                    var globalVar = _.find(globalVars, {name: name});
+                    var globalVar = _.find(globalVars, { name: name });
                     return globalVar ? globalVar.value : null;
                 }
 
                 function setVar(name, fetchFn) {
-                    globalVars.push({name: name, fetchFn: fetchFn});
+                    globalVars.push({ name: name, fetchFn: fetchFn });
                     return thisSub;
                 }
 
@@ -1202,13 +1204,13 @@
                         throw new Error('GetOne is only applicable to an array subscription.');
                     }
                     if (_.isNil(args)) {
-                        return waitForDataReady().then(function() {
+                        return waitForDataReady().then(function () {
                             return null;
                         });
                         // throw new Error('GetOne requires parameters');
                     }
                     args = _.concat([getData()], arguments);
-                    return waitForDataReady().then(function() {
+                    return waitForDataReady().then(function () {
                         return _.find.apply(this, args);
                     });
                 }
@@ -1222,7 +1224,7 @@
                     if (isSingle()) {
                         throw new Error('GetOne is only applicable to an array subscription.');
                     }
-                    return waitForDataReady().then(function() {
+                    return waitForDataReady().then(function () {
                         return getData();
                     });
                 }
@@ -1251,7 +1253,7 @@
                         return;
                     }
                     destroyed = true;
-                    _.forEach(filteredDataSets, function(ds) {
+                    _.forEach(filteredDataSets, function (ds) {
                         ds.destroy();
                     });
 
@@ -1266,7 +1268,7 @@
                 }
 
                 function createSubSet(filter, scope) {
-                    var fds = new FilteredSubSet(thisSub, filter, scope, function() {
+                    var fds = new FilteredSubSet(thisSub, filter, scope, function () {
                         _.remove(filteredDataSets, fds);
                     });
                     filteredDataSets.push(fds);
@@ -1279,7 +1281,7 @@
                 * If not all subsets rely on external data for filtering, a refresh method can be called on the subset that does for increased performance.
                 */
                 function refreshSubSets() {
-                    return $pq.all(_.map(filteredDataSets, function(subSet) {
+                    return $pq.all(_.map(filteredDataSets, function (subSet) {
                         return subSet.refresh();
                     }));
                 }
@@ -1489,20 +1491,20 @@
 
                 function mapExternalSubscriptionToProperty(propertyName, fetchFn, idProperty) {
                     dependentSubscriptions.push(fetchFn);
-                    mapPropertyFns.push(function(obj) {
+                    mapPropertyFns.push(function (obj) {
                         if (typeof obj[idProperty] === 'undefined') {
                             throw new Error('Undefined property ' + idProperty + ' of data received from subscription to ' + publication);
                         }
                         var fetchParams = {};
                         fetchParams.id = obj[idProperty];
-                        return fetchFn.setParameters(fetchParams).waitForDataReady().then(function(object) {
+                        return fetchFn.setParameters(fetchParams).waitForDataReady().then(function (object) {
                             obj[propertyName] = object;
                         });
                     });
                 }
 
                 function mapPromisedDataToProperty(propertyName, fetchFn, idProperty) {
-                    mapPropertyFns.push(function(obj) {
+                    mapPropertyFns.push(function (obj) {
                         var dot = propertyName.indexOf('.');
                         if (dot !== -1) {
                             var arrayName = propertyName.substring(0, dot);
@@ -1520,7 +1522,7 @@
                                 return fetchAndSet(obj, idProperty, itemPropertyName);
                             }
 
-                            return $pq.all(_.map(obj[arrayName], function(item) {
+                            return $pq.all(_.map(obj[arrayName], function (item) {
                                 if (typeof item[idProperty] === 'undefined') {
                                     throw new Error('Undefined property ' + idProperty + ' in array ' + propertyName + ' of data received from subscription to ' + publication);
                                 }
@@ -1537,9 +1539,9 @@
                     function fetchAndSet(obj, idProperty, propertyName) {
                         var result = fetchFn(obj[idProperty]);
                         if (result && result.then) {
-                            return result.then(function(value) {
+                            return result.then(function (value) {
                                 obj[propertyName] = value;
-                            }, function(err) {
+                            }, function (err) {
                                 throw new Error('Fetching error for property mapping ' + idProperty + ' in data received from subscription to ' + publication + '. err: ' + err);
                             });
                         }
@@ -1638,15 +1640,15 @@
                  * @returns <Promise> returns a promise that is resolved when the object is completely mapped
                  */
                 function mapAllDataToObject(obj, operation) {
-                    return $pq.all(_.map(globalVars, function(varObj) {
-                        return varObj.fetchFn().then(function(data) {
+                    return $pq.all(_.map(globalVars, function (varObj) {
+                        return varObj.fetchFn().then(function (data) {
                             varObj.value = data;
                         });
-                    })).then(function() {
-                        return $syncMapping.mapObjectPropertiesToSubscriptionData(thisSub, obj).then(function(obj) {
+                    })).then(function () {
+                        return $syncMapping.mapObjectPropertiesToSubscriptionData(thisSub, obj).then(function (obj) {
                             // , operation) {
                             return mapFullObject(obj, operation);
-                        }).catch(function(err) {
+                        }).catch(function (err) {
                             logError('Error when mapping received object.', err);
                             $pq.reject(err);
                         });
@@ -1666,11 +1668,11 @@
                   *
                  */
                 function mapFullObject(obj, operation) {
-                    return mapAllRecordProperties(obj, operation).then(function() {
+                    return mapAllRecordProperties(obj, operation).then(function () {
                         if (mapCustomDataFn) {
                             var result = mapCustomDataFn(obj, operation, getVars());
                             if (result && result.then) {
-                                return result.then(function() {
+                                return result.then(function () {
                                     return obj;
                                 });
                             }
@@ -1692,7 +1694,7 @@
                  * @param {*} operation
                  */
                 function mapAllRecordProperties(obj, operation) {
-                    return $pq.all(_.map(mapPropertyFns, function(mapPropertyFn) {
+                    return $pq.all(_.map(mapPropertyFns, function (mapPropertyFn) {
                         // property mapping does not need to clear the property mapping when cache is cleaned.
                         // -> means mapData will no be called in case on cache cleaning.
                         // this is not a problem except if the developer uses mapData function for other thing that mapping data.
@@ -1706,7 +1708,7 @@
                         try {
                             var result = mapPropertyFn(obj, operation);
                             if (result && result.then) {
-                                return result.then(function() {
+                                return result.then(function () {
                                     return obj;
                                 });
                             }
@@ -1724,8 +1726,8 @@
                 }
 
                 function $notifyUpdateWithinDependentSubscription(idOfObjectImpactedByChange) {
-                    var cachedObject = getRecordState({id: idOfObjectImpactedByChange});
-                    syncListener.notify('ready', getData(), [cachedObject]);
+                    var cachedObject = getRecordState({ id: idOfObjectImpactedByChange });
+                    syncListener.notify('ready', getData(), [cachedObject], true);
                 }
 
                 /**
@@ -1780,7 +1782,7 @@
                  * @returns {Promise} that waits for the initial fetch to complete then wait for the initial fetch to complete then returns this subscription.
                  */
                 function waitForSubscriptionReady(callback) {
-                    return startSyncing().then(function() {
+                    return startSyncing().then(function () {
                         if (callback) {
                             callback(thisSub);
                         }
@@ -1795,7 +1797,7 @@
                  * @returns {Promise} that waits for the initial fetch to complete then returns the data
                  */
                 function waitForDataReady(callback) {
-                    return startSyncing().then(function(data) {
+                    return startSyncing().then(function (data) {
                         if (callback) {
                             callback(data, thisSub);
                         }
@@ -1816,7 +1818,7 @@
                         cache = ObjectClass ? clearObject(new ObjectClass({})) : {};
                         cache.timestamp = {
                             $empty: true,
-                            $sync: thisSub,
+                            $sync: thisSub
                         };
                     } else {
                         updateFn = updateSyncedArray;
@@ -1871,7 +1873,7 @@
                     if (isSingleObjectCache) {
                         return cache.id === id ? cache : null;
                     }
-                    return _.find(cache, {id: id});
+                    return _.find(cache, { id: id });
                 }
 
                 /**
@@ -1950,7 +1952,7 @@
                         // better solution would be that the external subscription let know this subscription that is params has been modified, then only we would refresh
                         // the mapping.
                         if (dependentSubscriptions.length) {
-                            deferredInitialization.promise.then(function(data) {
+                            deferredInitialization.promise.then(function (data) {
                                 refreshMapping(getData());
                             });
                         }
@@ -1978,7 +1980,7 @@
                     }
                     var initializationPromise = deferredInitialization;
                     var completed = false;
-                    setTimeout(function() {
+                    setTimeout(function () {
                         if (!completed && deferredInitialization === initializationPromise) {
                             logError('Failed to load data within ' + initializationTimeout / 1000 + 's for ' + thisSub);
                             initializationPromise.reject('sync timeout');
@@ -1986,7 +1988,7 @@
                             thisSub.syncOff();
                         }
                     }, initializationTimeout);
-                    initializationPromise.promise.then(function() {
+                    initializationPromise.promise.then(function () {
                         completed = true;
                     });
                 }
@@ -1998,11 +2000,11 @@
                             listenForReconnectionToResync();
                         }
 
-                        publicationListenerOff = addPublicationListener(publication, function(batch) {
+                        publicationListenerOff = addPublicationListener(publication, function (batch) {
                             // Create a delay before processing publication data to simulate network latency
                             if (latencyInMilliSecs) {
                                 isLogInfo && logInfo('Sync -> Processing delayed for ' + latencyInMilliSecs + ' ms.'); //
-                                setTimeout(function() {
+                                setTimeout(function () {
                                     isLogInfo && logInfo('Sync -> Processing ' + publication + ' now.');
                                     processPublicationData(batch);
                                 }, latencyInMilliSecs);
@@ -2050,7 +2052,7 @@
                         isLogDebug && logDebug('Release not necessary (unattached): ' + thisSub);
                     } else {
                         isLogDebug && logDebug('Releasing subscription in ' + releaseDelay / 1000 + 's: ' + thisSub);
-                        releaseTimeout = setTimeout(function() {
+                        releaseTimeout = setTimeout(function () {
                             if (releaseTimeout) {
                                 isLogInfo && logInfo('Subscription released: ' + thisSub);
                                 thisSub.syncOff();
@@ -2077,7 +2079,7 @@
                         destroyOff();
                     }
                     innerScope = $rootScope;
-                    _.forEach(dependentSubscriptions, function(dsub) {
+                    _.forEach(dependentSubscriptions, function (dsub) {
                         dsub.detach();
                     });
                 }
@@ -2121,7 +2123,7 @@
                     innerScope = newScope;
                     var destroyScope = innerScope; // memorize scope as it is used during destroy
 
-                    destroyOff = innerScope.$on('$destroy', function() {
+                    destroyOff = innerScope.$on('$destroy', function () {
                         syncListener.dropListeners(destroyScope);
                         if (delayRelease) {
                             scheduleRelease();
@@ -2130,7 +2132,7 @@
                         }
                     });
 
-                    _.forEach(dependentSubscriptions, function(dsub) {
+                    _.forEach(dependentSubscriptions, function (dsub) {
                         dsub.attach(newScope, delayRelease);
                     });
                     return thisSub;
@@ -2138,8 +2140,8 @@
 
                 function listenForReconnectionToResync(listenNow) {
                     // give a chance to connect before listening to reconnection... @TODO should have user_reconnected_event
-                    setTimeout(function() {
-                        reconnectOff = innerScope.$on('user_connected', function() {
+                    setTimeout(function () {
+                        reconnectOff = innerScope.$on('user_connected', function () {
                             isLogDebug && logDebug('Resyncing after network loss to ' + publication);
                             // note the backend might return a new subscription if the client took too much time to reconnect.
                             registerSubscription();
@@ -2160,8 +2162,8 @@
                         version: SYNC_VERSION,
                         id: subscriptionId, // to try to re-use existing subcription
                         publication: publication,
-                        params: subParams,
-                    }).then(function(subId) {
+                        params: subParams
+                    }).then(function (subId) {
                         // registration might complete after an order to syncOff.
                         if (isSyncingOn) {
                             // syncing is on, let's remember the subId for potential reconnect to prevent refetching all data.
@@ -2177,7 +2179,7 @@
                             id: subscriptionId,
                             // following only useful for unit testing
                             publication: publication,
-                            params: subParams,
+                            params: subParams
                         });
                         subscriptionId = null;
                     }
@@ -2230,18 +2232,19 @@
                     // cannot only listen to subscriptionId yet...because the registration might have answer provided its id yet...but started broadcasting changes...@TODO can be improved...
                     if (subscriptionId === batch.subscriptionId || !subscriptionId && checkDataSetParamsIfMatchingBatchParams(batch.params)) {
                         var startTime = Date.now();
+                        var dataReceivedIn = Date.now() - initialStartTime;
                         var size = benchmark && isLogInfo ? JSON.stringify(batch.records).length : null;
 
-                        return cleanCache(batch.records, !batch.diff).then(function() {
+                        return cleanCache(batch.records, !batch.diff).then(function () {
                             return applyChanges(batch.records, false);
-                        }).then(function() {
+                        }).then(function () {
                             if (!isInitialPushCompleted) {
                                 isInitialPushCompleted = true;
 
                                 if (benchmark && isLogInfo) {
-                                    var timeToReceive = Date.now() - initialStartTime;
-                                    var timeToProcess = Date.now() - startTime;
-                                    isLogInfo && logInfo('Initial sync total time for ' + publication + ': ' + (timeToReceive + timeToProcess) + 'ms - Data Received in: ' + timeToReceive + 'ms, applied in: ' + timeToProcess + 'ms - Estimated size: ' + formatSize(size) + ' - Records: ' + batch.records.length + ' - Avg size/time: ' + formatSize(size / (batch.records.length || 1)) + '/' + roundNumber(timeToProcess / (batch.records.length || 1), 2) + 'ms');
+                                    var totalInitialToReady = Date.now() - initialStartTime;
+                                    var applyTime = Date.now() - startTime;
+                                    isLogInfo && logInfo('Initial sync total time for ' + publication + ': ' + totalInitialToReady + 'ms - Data Received in: ' + dataReceivedIn.toFixed(3) + 'ms, applied in: ' + applyTime.toFixed(3) + 'ms - Estimated size: ' + formatSize(size) + ' - Records: ' + batch.records.length + ' - Avg size/time: ' + formatSize(size / (batch.records.length || 1)) + '/' + roundNumber(applyTime / (batch.records.length || 1), 2) + 'ms');
                                 }
                                 deferredInitialization.resolve(getData());
                             }
@@ -2288,7 +2291,7 @@
                     } else {
                         result = cleanObjectCache();
                     }
-                    return result.catch(function(err) {
+                    return result.catch(function (err) {
                         logError('Error clearing subscription cache - ' + err);
                     });
                 }
@@ -2303,8 +2306,8 @@
                  */
                 function findRecordsPresentInCacheOnly(receivedRecordsToBeSynced) {
                     var deletedRecords = [];
-                    _.forEach(recordStates, function(cachedRecord, id) {
-                        if (!_.find(receivedRecordsToBeSynced, function(record) {
+                    _.forEach(recordStates, function (cachedRecord, id) {
+                        if (!_.find(receivedRecordsToBeSynced, function (record) {
                             return id === getIdValue(record.id);
                         })) {
                             deletedRecords.push(cachedRecord);
@@ -2321,13 +2324,13 @@
                  */
                 function cleanArrayCache(records) {
                     var promises = [];
-                    _.forEach(records, function(obj) {
+                    _.forEach(records, function (obj) {
                         $syncMapping.removePropertyMappers(thisSub, obj);
                         obj.removed = true;
                         promises.push(mapFullObject(obj, 'clear'));
                         delete recordStates[getIdValue(obj.id)];
                     });
-                    return $pq.all(promises).catch(function(err) {
+                    return $pq.all(promises).catch(function (err) {
                         logError('Error clearing subscription cache - ' + err);
                     });
                 }
@@ -2378,7 +2381,7 @@
                         if (!isSingle()) {
                             var orderedCache = _.orderBy(cache, fields, orders);
                             cache.length = 0;
-                            _.forEach(orderedCache, function(rec) {
+                            _.forEach(orderedCache, function (rec) {
                                 cache.push(rec);
                             });
                         }
@@ -2424,27 +2427,27 @@
                  */
                 function applyChanges(records, force) {
                     thisSub.ready = false;
-                    return waitForExternalDatasourcesReady().then(function() {
+                    return waitForExternalDatasourcesReady().then(function () {
                         try {
                             var newDataArray = [];
                             var promises = [];
-                            records.forEach(function(record) {
+                            records.forEach(function (record) {
                                 //                   isInfo && logInfo('Datasync [' + dataStreamName + '] received:' +JSON.stringify(record));//+ JSON.stringify(record.id));
                                 if (record.remove) {
                                     promises.push(removeRecord(record, force));
                                 } else if (getRecordState(record)) {
                                     // if the record is already present in the cache...so it is mightbe an update..
-                                    promises.push(updateRecord(record, force).then(function(newData) {
+                                    promises.push(updateRecord(record, force).then(function (newData) {
                                         newDataArray.push(newData);
                                     }));
                                 } else {
                                     // if the record is already present in the cache...so it is mightbe an update..
-                                    promises.push(addRecord(record, force).then(function(newData) {
+                                    promises.push(addRecord(record, force).then(function (newData) {
                                         newDataArray.push(newData);
                                     }));
                                 }
                             });
-                            return $pq.all(promises).then(function() {
+                            return $pq.all(promises).then(function () {
                                 // if order alterered, re-order
                                 if (newDataArray.length && orderByFn) {
                                     orderByFn();
@@ -2464,16 +2467,16 @@
                     return {
                         then: function then(cb) {
                             return cb();
-                        },
+                        }
                     }; // $pq.resolve();
                 }
 
                 function notifyDataReady(newDataArray) {
                     thisSub.ready = true;
                     if (isSingleObjectCache) {
-                        syncListener.notify('ready', getData());
+                        syncListener.notify('ready', getData(), null, true);
                     } else {
-                        syncListener.notify('ready', getData(), newDataArray);
+                        syncListener.notify('ready', getData(), newDataArray, true);
                     }
                 }
 
@@ -2537,12 +2540,13 @@
                  * @param {boolean} force (let us know if the addition was done by sync, or forcing record manually)
                  */
                 function addRecord(record, force) {
-                    isLogDebug && logDebug('Sync -> Inserted New record #' + JSON.stringify(record.id) + (force ? ' directly' : ' via sync') + ' for subscription to ' + thisSub); // JSON.stringify(record));
+                    // trace can be very verbose
+                    isLogTrace && logTrace('Sync -> Inserted New record #' + JSON.stringify(record.id) + (force ? ' directly' : ' via sync') + ' for subscription to ' + thisSub); // JSON.stringify(record));
                     getRevision(record); // just make sure we can get a revision before we handle this record
 
                     var obj = formatRecord ? formatRecord(record) : record;
 
-                    return mapAllDataToObject(obj, 'add').then(function() {
+                    return mapAllDataToObject(obj, 'add').then(function () {
                         obj = updateDataStorage(obj, force);
                         syncListener.notify('add', obj);
                         return obj;
@@ -2581,7 +2585,7 @@
                     isLogDebug && logDebug('Sync -> Updated record #' + JSON.stringify(record.id) + (force ? ' directly' : ' via sync') + ' for subscription to ' + thisSub);
                     obj = formatRecord ? formatRecord(record) : record;
 
-                    return mapAllDataToObject(obj, 'update').then(function() {
+                    return mapAllDataToObject(obj, 'update').then(function () {
                         obj = updateDataStorage(obj, force);
                         syncListener.notify('update', obj);
                         return obj;
@@ -2659,7 +2663,7 @@
                         merge(cache, record);
                     } else {
                         clearObject(cache);
-                        cache.timestamp = {$empty: true};
+                        cache.timestamp = { $empty: true };
                     }
                     return cache;
                 }
@@ -2697,7 +2701,7 @@
                 }
 
                 function clearObject(object) {
-                    Object.keys(object).forEach(function(key) {
+                    Object.keys(object).forEach(function (key) {
                         delete object[key];
                     });
                     return object;
@@ -2718,7 +2722,7 @@
             /**
              * this object
              */
-            function SyncListener() {
+            function SyncListener(subscription) {
                 var events = {};
                 var count = 0;
 
@@ -2727,8 +2731,8 @@
                 this.dropListeners = dropListeners;
 
                 function dropListeners(scope) {
-                    _.forEach(events, function(listeners) {
-                        _.forEach(listeners, function(listener, id) {
+                    _.forEach(events, function (listeners) {
+                        _.forEach(listeners, function (listener, id) {
                             if (listener.scope === scope) {
                                 delete listeners[id];
                             }
@@ -2737,11 +2741,23 @@
                 }
 
                 function notify(event, data1, data2) {
+                    var timingCapable = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+
                     var listeners = events[event];
+                    var subDef = void 0;
+                    if (timingCapable === true && !_.isEmpty(listeners)) {
+                        subDef = function subDef() {
+                            return 'Applied notified event [' + event + '] : ' + subscription.getPublication() + JSON.stringify(subscription.getParameters());
+                        };
+                        logTime(subDef);
+                    }
                     if (listeners) {
-                        _.forEach(listeners, function(listener, id) {
+                        _.forEach(listeners, function (listener, id) {
                             listener.notify(data1, data2);
                         });
+                    }
+                    if (timingCapable === true && !_.isEmpty(listeners)) {
+                        logTimeEnd(subDef);
                     }
                 }
 
@@ -2756,9 +2772,9 @@
                     var id = count++;
                     listeners[id] = {
                         notify: callback,
-                        scope: scope,
+                        scope: scope
                     };
-                    return function() {
+                    return function () {
                         delete listeners[id];
                     };
                 }
@@ -2770,7 +2786,7 @@
                 return id;
             }
             // build composite key value
-            var r = _.join(_.map(id, function(value) {
+            var r = _.join(_.map(id, function (value) {
                 return value;
             }), '~');
             return r;
@@ -2789,6 +2805,24 @@
         function logDebug(msg) {
             if (isLogDebug) {
                 console.debug('SYNC(debug): ', _.isFunction(msg) ? msg() : msg);
+            }
+        }
+
+        function logTrace(msg) {
+            if (isLogTrace) {
+                console.debug('SYNC(trace): ', _.isFunction(msg) ? msg() : msg);
+            }
+        }
+
+        function logTime(label) {
+            if (isLogDebug) {
+                console.time('SYNC(debug): ' + (_.isFunction(label) ? label() : label));
+            }
+        }
+
+        function logTimeEnd(label) {
+            if (isLogDebug) {
+                console.timeEnd('SYNC(debug): ' + (_.isFunction(label) ? label() : label));
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "url": ""
   },
-  "version": "1.2.12",
+  "version": "1.2.13",
   "dependencies": {
     "angular": "1.7.9",
     "lodash": "4.17.15"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "url": ""
   },
-  "version": "1.2.11",
+  "version": "1.2.12",
   "dependencies": {
     "angular": "1.7.9",
     "lodash": "4.17.15"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "version": "1.2.13",
   "dependencies": {
     "angular": "1.7.9",
-    "lodash": "4.17.15"
+    "lodash": "4.17.19"
   },
   "devDependencies": {
     "angular-mocks": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "url": ""
   },
-  "version": "1.2.13",
+  "version": "1.2.12",
   "dependencies": {
     "angular": "1.7.9",
     "lodash": "4.17.19"

--- a/src/services/sync.service.js
+++ b/src/services/sync.service.js
@@ -1381,7 +1381,7 @@ function syncProvider($syncMappingProvider) {
                     if (!completed && deferredInitialization === initializationPromise) {
                         logError('Failed to load data within ' + (initializationTimeout / 1000) + 's for ' + thisSub);
                         initializationPromise.reject('sync timeout');
-                        // give up syncing.
+                        // give up syncing and release resources.
                         thisSub.syncOff();
                     }
                 }, initializationTimeout);
@@ -1541,10 +1541,10 @@ function syncProvider($syncMappingProvider) {
             }
 
             function listenForReconnectionToResync(listenNow) {
-                // give a chance to connect before listening to reconnection... @TODO should have user_reconnected_event
+                // give a chance to connect before listening to reconnection.
                 setTimeout(function() {
-                    reconnectOff = innerScope.$on('user_connected', function() {
-                        isLogDebug && logDebug('Resyncing after network loss to ' + publication);
+                    reconnectOff = innerScope.$on('user_reconnected', function() {
+                        isLogDebug && logDebug('Resyncing after network loss to ' + publication + JSON.stringify(thisSub.getParameters()));
                         // note the backend might return a new subscription if the client took too much time to reconnect.
                         registerSubscription();
                     });

--- a/src/services/sync.service.js
+++ b/src/services/sync.service.js
@@ -26,13 +26,14 @@ angular
 function syncProvider($syncMappingProvider) {
     let totalSub = 0, strictCode = false;
 
-    let benchmark = true, isLogDebug, isLogInfo, defaultReleaseDelay = 30, defaultInitializationTimeout = 10;
+    let benchmark = true, isLogDebug, isLogInfo, isLogTrace, defaultReleaseDelay = 30, defaultInitializationTimeout = 10;
 
     let latencyInMilliSecs = 0;
 
     this.setDebug = function(value) {
         isLogInfo = value >= 1;
-        isLogDebug = value === 2;
+        isLogDebug = value >= 2;
+        isLogTrace = value >= 3;
         $syncMappingProvider.setDebug(isLogDebug);
         return this;
     };
@@ -449,7 +450,7 @@ function syncProvider($syncMappingProvider) {
             let subParams = {};
             let recordStates = {};
             let innerScope; // = $rootScope.$new(true);
-            const syncListener = new SyncListener();
+            const syncListener = new SyncListener(thisSub);
 
 
             let dependentSubscriptions = [];
@@ -1119,7 +1120,7 @@ function syncProvider($syncMappingProvider) {
 
             function $notifyUpdateWithinDependentSubscription(idOfObjectImpactedByChange) {
                 const cachedObject = getRecordState({id: idOfObjectImpactedByChange});
-                syncListener.notify('ready', getData(), [cachedObject]);
+                syncListener.notify('ready', getData(), [cachedObject], true);
             }
 
 
@@ -1635,6 +1636,7 @@ function syncProvider($syncMappingProvider) {
                 // cannot only listen to subscriptionId yet...because the registration might have answer provided its id yet...but started broadcasting changes...@TODO can be improved...
                 if (subscriptionId === batch.subscriptionId || (!subscriptionId && checkDataSetParamsIfMatchingBatchParams(batch.params))) {
                     const startTime = Date.now();
+                    const dataReceivedIn = Date.now() - initialStartTime;
                     const size = benchmark && isLogInfo ? JSON.stringify(batch.records).length : null;
 
                     return cleanCache(batch.records, !batch.diff)
@@ -1646,9 +1648,9 @@ function syncProvider($syncMappingProvider) {
                                 isInitialPushCompleted = true;
 
                                 if (benchmark && isLogInfo) {
-                                    const timeToReceive = Date.now() - initialStartTime;
-                                    const timeToProcess = Date.now() - startTime;
-                                    isLogInfo && logInfo('Initial sync total time for ' + publication + ': ' + (timeToReceive + timeToProcess) + 'ms - Data Received in: ' + timeToReceive + 'ms, applied in: ' + timeToProcess + 'ms - Estimated size: ' + formatSize(size) + ' - Records: ' + batch.records.length + ' - Avg size/time: ' + formatSize(size / (batch.records.length || 1)) + '/' + roundNumber(timeToProcess / (batch.records.length || 1), 2) + 'ms');
+                                    const totalInitialToReady = Date.now() - initialStartTime;
+                                    const applyTime = Date.now() - startTime;
+                                    isLogInfo && logInfo('Initial sync total time for ' + publication + ': ' + totalInitialToReady + 'ms - Data Received in: ' + dataReceivedIn.toFixed(3) + 'ms, applied in: ' + applyTime.toFixed(3) + 'ms - Estimated size: ' + formatSize(size) + ' - Records: ' + batch.records.length + ' - Avg size/time: ' + formatSize(size / (batch.records.length || 1)) + '/' + roundNumber(applyTime / (batch.records.length || 1), 2) + 'ms');
                                 }
                                 deferredInitialization.resolve(getData());
                             }
@@ -1881,9 +1883,9 @@ function syncProvider($syncMappingProvider) {
             function notifyDataReady(newDataArray) {
                 thisSub.ready = true;
                 if (isSingleObjectCache) {
-                    syncListener.notify('ready', getData());
+                    syncListener.notify('ready', getData(), null, true);
                 } else {
-                    syncListener.notify('ready', getData(), newDataArray);
+                    syncListener.notify('ready', getData(), newDataArray, true);
                 }
             }
 
@@ -1949,7 +1951,8 @@ function syncProvider($syncMappingProvider) {
              * @param {boolean} force (let us know if the addition was done by sync, or forcing record manually)
              */
             function addRecord(record, force) {
-                isLogDebug && logDebug('Sync -> Inserted New record #' + JSON.stringify(record.id) + (force ? ' directly' : ' via sync') + ' for subscription to ' + thisSub); // JSON.stringify(record));
+                // trace can be very verbose
+                isLogTrace && logTrace('Sync -> Inserted New record #' + JSON.stringify(record.id) + (force ? ' directly' : ' via sync') + ' for subscription to ' + thisSub); // JSON.stringify(record));
                 getRevision(record); // just make sure we can get a revision before we handle this record
 
                 let obj = formatRecord ? formatRecord(record) : record;
@@ -2132,7 +2135,7 @@ function syncProvider($syncMappingProvider) {
         /**
          * this object
          */
-        function SyncListener() {
+        function SyncListener(subscription) {
             const events = {};
             let count = 0;
 
@@ -2150,12 +2153,20 @@ function syncProvider($syncMappingProvider) {
                 });
             }
 
-            function notify(event, data1, data2) {
+            function notify(event, data1, data2, timingCapable = false) {
                 const listeners = events[event];
+                let subDef;
+                if (timingCapable === true && !_.isEmpty(listeners)) {
+                    subDef = () => 'Applied notified event [' + event + '] : ' + subscription.getPublication() + JSON.stringify(subscription.getParameters());
+                    logTime(subDef);
+                }
                 if (listeners) {
                     _.forEach(listeners, function(listener, id) {
                         listener.notify(data1, data2);
                     });
+                }
+                if (timingCapable === true && !_.isEmpty(listeners)) {
+                    logTimeEnd(subDef);
                 }
             }
 
@@ -2204,6 +2215,24 @@ function syncProvider($syncMappingProvider) {
     function logDebug(msg) {
         if (isLogDebug) {
             console.debug('SYNC(debug): ', (_.isFunction(msg) ? msg() : msg));
+        }
+    }
+
+    function logTrace(msg) {
+        if (isLogTrace) {
+            console.debug('SYNC(trace): ', (_.isFunction(msg) ? msg() : msg));
+        }
+    }
+
+    function logTime(label) {
+        if (isLogDebug) {
+            console.time('SYNC(debug): ' + (_.isFunction(label) ? label() : label));
+        }
+    }
+
+    function logTimeEnd(label) {
+        if (isLogDebug) {
+            console.timeEnd('SYNC(debug): ' + (_.isFunction(label) ? label() : label));
         }
     }
 

--- a/test/specs/basic-sync.service.spec.js
+++ b/test/specs/basic-sync.service.spec.js
@@ -922,7 +922,7 @@ describe('Basic Sync Service: ', function() {
                 // expect(spec.sds.getData().length).toEqual(2);
                 done();
             });
-            $scope.$broadcast('user_connected');
+            $scope.$broadcast('user_reconnected');
             expect(spec.$socketio.fetch.calls.count()).toEqual(2);
             // 2nd subscription for reconnect
             expect(spec.$socketio.fetch.calls.mostRecent().args[0]).toEqual('sync.subscribe');


### PR DESCRIPTION
Improve the console output on debug mode to display more accurate timing.

- The message for Initial sync total time was off. It was including twice the apply time to process the received data
- The time to process onReady is now output. This is the event where the developer might usually do lots of processing after the data is received into the subscription. Too much processing might freeze the browser and leads to lose network connection.

the function setDebug can receive the value 3 to output the trace log level.

Run the tests: npm test
Run the linting: npm run eslint
