### PR TITLE
7399 - ET - Remove auto release

### DIFF
--- a/dist/zerv-ng-sync-mock.js
+++ b/dist/zerv-ng-sync-mock.js
@@ -115,16 +115,14 @@ angular
     .provider('mockSyncServer', mockSyncServer);
 
 function mockSyncServer() {
-
     var debug;
 
-    this.setDebug = function (value) {
+    this.setDebug = function(value) {
         debug = value;
     };
 
 
     this.$get = ["$rootScope", "$pq", "$socketio", "$sync", "publicationService", function sync($rootScope, $pq, $socketio, $sync, publicationService) {
-
         var publicationsWithSubscriptions = publicationService;
         var subCount = 0;
 
@@ -145,15 +143,14 @@ function mockSyncServer() {
             acknowledge: acknowledge,
 
 
+            setData: setData,
+        };
 
-            setData: setData
-        }
-
-        $socketio.onFetch('sync.subscribe', function () {
+        $socketio.onFetch('sync.subscribe', function() {
             return service.subscribe.apply(self, arguments);
         });
 
-        $socketio.onFetch('sync.unsubscribe', function () {
+        $socketio.onFetch('sync.unsubscribe', function() {
             return service.unsubscribe.apply(self, arguments);
         });
 
@@ -208,7 +205,7 @@ function mockSyncServer() {
          */
         function publish(definition) {
             if (_.isArray(definition)) {
-                _.forEach(definition, function (def) {
+                _.forEach(definition, function(def) {
                     if (!def.type) {
                         throw new Error('Publish array argument must contain objects with a type property ("object" or "array")');
                     }
@@ -217,7 +214,7 @@ function mockSyncServer() {
                     } else {
                         publishObject(def.sub, def.data);
                     }
-                })
+                });
             } else if (_.isObject(definition)) {
                 publishObject(definition.sub, definition.data);
             } else {
@@ -232,15 +229,13 @@ function mockSyncServer() {
          *   if not provided, a default publication will be created
          */
         function setData(subParams, data) {
-            data.forEach(function (record) {
+            data.forEach(function(record) {
                 if (_.isNil(record.revision)) {
                     throw new Error('Objects in publication must have a revision and id. Check you unit test data for ' + JSON.stringify(subParams));
                 }
             });
             return publicationsWithSubscriptions.create(data, subParams.publication, subParams.params);
         }
-
-
 
 
         function notifyDataUpdate(subParams, data) {
@@ -261,18 +256,20 @@ function mockSyncServer() {
             }
 
             data = publication.remove(data);
-            _.forEach(data, function (record) { record.remove = new Date(); });
+            _.forEach(data, function(record) {
+                record.remove = new Date();
+            });
             return notifySubscriptions(publication, data);
         }
 
         function notifySubscriptions(publication, data) {
-            var r = $pq.all(_.map(publication.subscriptionIds, function (id) {
+            var r = $pq.all(_.map(publication.subscriptionIds, function(id) {
                 return onPublicationNotficationCallback({
                     name: publication.name,
                     subscriptionId: id,
                     params: publication.params,
                     records: data,
-                    diff: true
+                    diff: true,
                 }, service.acknowledge);
             }));
             if (!$rootScope.$$phase) {
@@ -282,7 +279,6 @@ function mockSyncServer() {
                 // when the digest completes, the notification has been processed by the client, UI might have reacted too.
             }
             return r;
-
         }
 
         function subscribe(subParams) {
@@ -306,21 +302,19 @@ function mockSyncServer() {
                 publication.subscriptionIds.push(subId);
             }
 
-            return $pq.resolve(subId).then(function (subId) {
-                publication.subId = subId;
-                onPublicationNotficationCallback({
-                    name: publication.name,
-                    subscriptionId: subId,  // this is the id for the new subscription.
-                    params: publication.params,
-                    records: publication.getData(),
-                }, service.acknowledge);
-                return subId;
-            });
+            publication.subId = subId;
+            onPublicationNotficationCallback({
+                name: publication.name,
+                subscriptionId: subId, // this is the id for the new subscription.
+                params: publication.params,
+                records: publication.getData(),
+            }, service.acknowledge);
+            return $pq.resolve(subId);
         }
 
         function unsubscribe(subParams) {
             publicationsWithSubscriptions.release(subParams.id, subParams.publication, subParams.params);
-            logDebug("Unsubscribed: " + JSON.stringify(subParams));
+            logDebug('Unsubscribed: ' + JSON.stringify(subParams));
             return $pq.resolve();
         }
 
@@ -342,7 +336,7 @@ function mockSyncServer() {
                 console.debug('MOCKSERV: ' + msg);
             }
         }
-    }]
+    }];
 }
 }());
 
@@ -364,14 +358,14 @@ function publicationService($sync) {
 
     function findBySubscriptionId(id) {
         // find the data for this subscription
-        return _.find(publications, function (pub) {
+        return _.find(publications, function(pub) {
             return _.indexOf(pub.subscriptionIds, id) !== -1;
         });
     }
 
     function find(name, params) {
         // find the data for this subscription
-        return _.find(publications, function (pub) {
+        return _.find(publications, function(pub) {
             return pub.name === name && (
                 (params && pub.params && _.isEqual(params, pub.params)) ||
                 (!params && !pub.params)
@@ -402,15 +396,14 @@ function publicationService($sync) {
     }
 
 
-
     function copyAll(array) {
         var r = [];
-        array.forEach(function (i) {
+        array.forEach(function(i) {
             if (!_.isObject(i)) {
                 throw new Error('Publication data cannot be null');
             }
             r.push(angular.copy(i));
-        })
+        });
         return r;
     }
 
@@ -421,36 +414,36 @@ function publicationService($sync) {
         this.subscriptionIds = [];
     }
 
-    Publication.prototype.hasSubscriptions = function () {
+    Publication.prototype.hasSubscriptions = function() {
         return this.subscriptionIds.length > 0;
-    }
+    };
 
-    Publication.prototype.reset = function (data) {
+    Publication.prototype.reset = function(data) {
         this.cache = {};
         this.update(data);
         return data;
-    }
+    };
 
-    Publication.prototype.update = function (data) {
+    Publication.prototype.update = function(data) {
         var self = this;
         data = copyAll(data);
-        data.forEach(function (record) {
+        data.forEach(function(record) {
             self.cache[$sync.getIdValue(record.id)] = record;
         });
         return data;
-    }
+    };
 
-    Publication.prototype.remove = function (data) {
+    Publication.prototype.remove = function(data) {
         var self = this;
         data = copyAll(data);
-        data.forEach(function (record) {
+        data.forEach(function(record) {
             delete self.cache[$sync.getIdValue(record.id)];
         });
         return data;
-    }
+    };
 
-    Publication.prototype.getData = function () {
+    Publication.prototype.getData = function() {
         return _.values(this.cache);
-    }
+    };
 }
 }());

--- a/dist/zerv-ng-sync.js
+++ b/dist/zerv-ng-sync.js
@@ -1336,7 +1336,7 @@
                  *
                  */
                 function setForce(value) {
-                    if (value && this.isSyncingOn) {
+                    if (value && isSyncingOn) {
                         thisSub.syncOff();
                     }
                     return thisSub;

--- a/dist/zerv-ng-sync.js
+++ b/dist/zerv-ng-sync.js
@@ -2082,7 +2082,7 @@
                  *
                  *
                  */
-                function attach(newScope, delayRelease) {
+                function attach(newScope) {
                     detach();
 
                     if (newScope === innerScope) {

--- a/dist/zerv-ng-sync.js
+++ b/dist/zerv-ng-sync.js
@@ -641,10 +641,10 @@
      *
      */
 
-    syncProvider.$inject = ["$syncMappingProvider"];
+    syncProvider.$inject = ["$syncMappingProvider", "$pqProvider"];
     angular.module('zerv.sync').provider('$sync', syncProvider);
 
-    function syncProvider($syncMappingProvider) {
+    function syncProvider($syncMappingProvider, $pqProvider) {
         var totalSub = 0,
             strictCode = false;
 
@@ -652,7 +652,6 @@
             isLogDebug = void 0,
             isLogInfo = void 0,
             isLogTrace = void 0,
-            defaultReleaseDelay = 30,
             defaultInitializationTimeout = 10;
 
         var latencyInMilliSecs = 0;
@@ -675,6 +674,15 @@
         };
 
         /**
+         * Mixing angular promises with native implementation can make unit test very difficult to implement.
+         * This forces the sync library to use native primitive implementation.
+         * In the future, sync will not longer support angular.
+         */
+        this.useNativePromiseImpl = function () {
+            $pqProvider.useBluebird();
+        };
+
+        /**
          *  add a delay before processing publication data to simulate network latency
          *
          * @param <number> milliseconds
@@ -682,16 +690,6 @@
          */
         this.setLatency = function (seconds) {
             latencyInMilliSecs = seconds;
-            return this;
-        };
-
-        /**
-         * Delay before a released subscription stop syncing (see attach)
-         *
-         *  @param <number> seconds
-         */
-        this.setReleaseDelay = function (seconds) {
-            defaultReleaseDelay = seconds * 1000;
             return this;
         };
 
@@ -793,8 +791,8 @@
             function listenToPublicationNotification() {
                 $socketio.on('SYNC_NOW', function (serializedObj, fn) {
                     var subNotification = deserialize(serializedObj);
-
-                    isLogInfo && logInfo('Syncing with [' + subNotification.name + ', id:' + subNotification.subscriptionId + ' , params:' + JSON.stringify(subNotification.params) + ']. Records:' + subNotification.records.length + '[' + (subNotification.diff ? 'Diff' : 'All') + ']');
+                    // data can be received from the socket
+                    isLogDebug && logDebug('Received to sync [' + subNotification.name + ', id:' + subNotification.subscriptionId + ' , params:' + JSON.stringify(subNotification.params) + ']. Records:' + subNotification.records.length + '[' + (subNotification.diff ? 'Diff' : 'All') + ']');
                     var listeners = publicationListeners[subNotification.name];
                     var processed = [];
                     if (listeners) {
@@ -896,7 +894,7 @@
                 }
 
                 /**
-                 * Attach this dataset, it will be released (no longer updating on sync) when the scope is destroyed;
+                 * Attach this dataset, it will be destroyed when the scope is destroyed;
                  *
                  * @param {*} newScope
                  */
@@ -1047,8 +1045,7 @@
 
             function Subscription(publication, scope) {
                 var isSyncingOn = false;
-                var destroyed = void 0,
-                    isSingleObjectCache = void 0,
+                var isSingleObjectCache = void 0,
                     updateDataStorage = void 0,
                     cache = void 0,
                     orderByFn = void 0,
@@ -1060,7 +1057,9 @@
                     formatRecord = void 0;
                 var reconnectOff = void 0,
                     publicationListenerOff = void 0,
-                    destroyOff = void 0;
+                    destroyOff = void 0,
+                    onDestroyOff = void 0,
+                    _initializationOff = void 0;
                 var ObjectClass = void 0;
                 var subscriptionId = void 0;
                 var mapCustomDataFn = void 0,
@@ -1076,12 +1075,13 @@
                 var syncListener = new SyncListener(thisSub);
 
                 var dependentSubscriptions = [];
-                var releaseDelay = defaultReleaseDelay;
                 var initializationTimeout = defaultInitializationTimeout;
 
-                var releaseTimeout = null;
-
                 //  ----public----
+                // to help debugging in the memory snapshot
+                this.publication = publication;
+                // ---------------
+
                 this.toString = toString;
                 this.getPublication = getPublication;
                 this.getIdb = getId;
@@ -1129,7 +1129,9 @@
 
                 this.setForce = setForce;
                 this.isSyncing = isSyncing;
+                this.isDestroyed = isDestroyed;
                 this.isReady = isReady;
+                this.isEmpty = isEmpty;
 
                 this.setSingle = setSingle;
                 this.isSingle = isSingle;
@@ -1141,10 +1143,9 @@
 
                 this.attach = attach;
                 this.detach = detach;
-                this.setDependentSubscriptions = setDependentSubscriptions;
-                this.setReleaseDelay = setReleaseDelay;
                 this.setInitializationTimeout = setInitializationTimeout;
                 this.destroy = destroy;
+                this.onDestroy = onDestroy;
 
                 this.isExistingStateFor = isExistingStateFor; // for testing purposes
 
@@ -1249,10 +1250,6 @@
                  * destroy this subscription but also dependent subscriptions if any
                  */
                 function destroy() {
-                    if (destroyed) {
-                        return;
-                    }
-                    destroyed = true;
                     _.forEach(filteredDataSets, function (ds) {
                         ds.destroy();
                     });
@@ -1265,6 +1262,21 @@
                     syncOff();
                     $syncMapping.destroyDependentSubscriptions(thisSub);
                     isLogDebug && logDebug('Subscription to ' + thisSub + ' destroyed.');
+
+                    detach();
+                    syncListener.notify('destroy', publication, subParams);
+                    onDestroyOff && onDestroyOff();
+                    thisSub.destroyed = true; // value is the object so that it can be seen in the mem snapshot.
+                }
+
+                function onDestroy(callback) {
+                    if (strictCode && onReadyOff) {
+                        throw new Error('onDestroy is already set in subscription to ' + publication + '. It cannot be resetted to prevent bad practice leading to potential memory leak . Consider using onDestroy when subscription is instantiated.');
+                    }
+                    onDestroyOff && onDestroyOff();
+                    // this onReady is not attached to any scope and will only be gone when the sub is destroyed
+                    onDestroyOff = syncListener.on('destroy', callback, null);
+                    return thisSub;
                 }
 
                 function createSubSet(filter, scope) {
@@ -1324,8 +1336,7 @@
                  *
                  */
                 function setForce(value) {
-                    if (value) {
-                        // quick hack to force to reload...recode later.
+                    if (value && this.isSyncingOn) {
                         thisSub.syncOff();
                     }
                     return thisSub;
@@ -1549,14 +1560,6 @@
                     }
                 }
 
-                // function mapPropertyDs(propertyName, externalDs, idProperty) {
-                //     dependentSubscriptions.push(externalDs);
-                //     var onReadyOff = externalDs.onReady(function() {
-                //         dependentSub.invalid = true; // means the external sub data has changed, making this subscription obj potentially mapped to wrong data
-                //     });
-                // }
-
-
                 /**
                  *  this function allows to add to the subscription multiple mapping strategies at the same time
                  *
@@ -1738,7 +1741,7 @@
                  * @returns {Promise} returns on object with the last synced data.
                  */
                 function load(fetchingParams, options) {
-                    return setParameters(fetchingParams, options).waitForDataReady();
+                    return this.setParameters(fetchingParams, options).waitForDataReady();
                 }
 
                 /**
@@ -1761,6 +1764,10 @@
                     cleanCache();
 
                     subParams = fetchingParams || {};
+
+                    // to help debugging using chrome memory snapshot
+                    this.subParams = subParams;
+
                     options = options || {};
                     if (angular.isDefined(options.single)) {
                         setSingle(options.single);
@@ -1892,24 +1899,33 @@
                  *
                  * the dataset is no longer listening and will not call any callback
                  *
+                 * A future option could be
+                 * - delay: which would stop the sync after a delay. This would be useful for
+                 *   dataset that are not destroyed and might be resused quickly going from one page
+                 *   to another.
+                 *   Otherwise, going to the next page will force to pull the data again from the network.
+                 * 
                  * @returns this subcription
+                 * 
                  */
                 function syncOff() {
                     if (isSyncingOn) {
                         unregisterSubscription();
                         isSyncingOn = false;
-
                         isLogInfo && logInfo('Sync ' + publication + ' off. Params:' + JSON.stringify(subParams));
-                        if (publicationListenerOff) {
-                            publicationListenerOff();
-                            publicationListenerOff = null;
-                        }
-                        if (reconnectOff) {
-                            reconnectOff();
-                            reconnectOff = null;
-                        }
                     }
-
+                    if (publicationListenerOff) {
+                        publicationListenerOff();
+                        publicationListenerOff = null;
+                    }
+                    if (reconnectOff) {
+                        reconnectOff();
+                        reconnectOff = null;
+                    }
+                    if (_initializationOff) {
+                        _initializationOff();
+                        _initializationOff = null;
+                    }
                     if (deferredInitialization) {
                         // if there is code waiting on this promise.. ex (load in resolve)
                         deferredInitialization.resolve(getData());
@@ -1939,6 +1955,10 @@
                  * @returns a promise that will be resolved when the data is ready.
                  */
                 function startSyncing() {
+                    if (thisSub.isDestroyed()) {
+                        // the sub was destroyed, just return the result of the initialization
+                        return deferredInitialization.promise;
+                    }
                     if (dependentSubscriptions.length && !isSingle()) {
                         throw new Error('Mapping to an external datasource can only be used when subscribing to a single object.');
                     }
@@ -1963,8 +1983,9 @@
                     isInitialPushCompleted = false;
                     isLogInfo && logInfo('Sync ' + publication + ' on. Params:' + JSON.stringify(subParams));
                     isSyncingOn = true;
-                    registerSubscription();
                     readyForListening();
+
+                    registerSubscription();
                     setTimeoutOnInitialization();
 
                     return deferredInitialization.promise;
@@ -1974,30 +1995,38 @@
                     return isSyncingOn;
                 }
 
+                function isDestroyed() {
+                    return thisSub.destroyed === true;
+                }
+
+                function isEmpty() {
+                    return thisSub.isSingle() ? cache.timestamp && cache.timestamp.$empty || false : cache.length === 0;
+                }
+
                 function setTimeoutOnInitialization() {
                     if (!initializationTimeout) {
                         return;
                     }
-                    var initializationPromise = deferredInitialization;
-                    var completed = false;
-                    setTimeout(function () {
-                        if (!completed && deferredInitialization === initializationPromise) {
-                            logError('Failed to load data within ' + initializationTimeout / 1000 + 's for ' + thisSub);
-                            initializationPromise.reject('sync timeout');
-                            // give up syncing and release resources.
-                            thisSub.syncOff();
-                        }
+                    var timeout = setTimeout(function () {
+                        logError('Failed to load data within ' + initializationTimeout / 1000 + 's for ' + thisSub);
+                        deferredInitialization.reject('sync timeout');
+                        // give up syncing and release resources.
+                        thisSub.syncOff();
                     }, initializationTimeout);
-                    initializationPromise.promise.then(function () {
-                        completed = true;
-                    });
+
+                    _initializationOff = function initializationOff() {
+                        clearTimeout(timeout);
+                        _initializationOff = null;
+                    };
+
+                    deferredInitialization.promise.then(_initializationOff).catch(_initializationOff);
                 }
 
                 function readyForListening() {
                     if (!publicationListenerOff) {
                         // if the subscription belongs to a parent one and the network is lost, the top parent subscription will release/destroy all dependent subscriptions and take care of re-registering itself and its dependents.
                         if (!thisSub.$parentSubscription) {
-                            listenForReconnectionToResync();
+                            reconnectOff = listenForReconnectionToResync();
                         }
 
                         publicationListenerOff = addPublicationListener(publication, function (batch) {
@@ -2015,51 +2044,8 @@
                     }
                 }
 
-                /**
-                 * set which external subscription this subscription depends on.
-                 * When this subscription is released, the other subscription will be released as well.
-                 *
-                 * When a subscription is released, it remains in sync for a little while to promote reuse.
-                 *
-                 * @param {Array} subscriptions
-                 */
-                function setDependentSubscriptions(subs) {
-                    dependentSubscriptions = subs;
-                    return thisSub;
-                }
-
-                /**
-                 * set the number of seconds before a subscription stops syncing after it is release for destruction.
-                 * This promotes re-use.
-                 *
-                 * @param {int} t in seconds
-                 */
-                function setReleaseDelay(t) {
-                    releaseDelay = t * 1000;
-                }
-
                 function setInitializationTimeout(t) {
                     initializationTimeout = t * 1000;
-                }
-
-                /**
-                 * Schedule this subscription to stop syncing after a lap of time (releaseDelay)
-                 *
-                 */
-                function scheduleRelease() {
-                    // detach must be called otherwise,  the subscription is planned for release.
-                    if (innerScope === $rootScope) {
-                        isLogDebug && logDebug('Release not necessary (unattached): ' + thisSub);
-                    } else {
-                        isLogDebug && logDebug('Releasing subscription in ' + releaseDelay / 1000 + 's: ' + thisSub);
-                        releaseTimeout = setTimeout(function () {
-                            if (releaseTimeout) {
-                                isLogInfo && logInfo('Subscription released: ' + thisSub);
-                                thisSub.syncOff();
-                                releaseTimeout = null;
-                            }
-                        }, Math.max(releaseDelay, initializationTimeout) + 500); // to make sure that a release does not happen during initialization
-                    }
                 }
 
                 /**
@@ -2069,19 +2055,10 @@
                  */
                 function detach() {
                     isLogDebug && logDebug('Detach subscription(release): ' + thisSub);
-                    // if sub was about to be released, keep it.
-                    if (releaseTimeout) {
-                        isLogInfo && logInfo('Re-use before release: ' + thisSub);
-                        clearTimeout(releaseTimeout);
-                        releaseTimeout = null;
-                    }
                     if (destroyOff) {
                         destroyOff();
                     }
                     innerScope = $rootScope;
-                    _.forEach(dependentSubscriptions, function (dsub) {
-                        dsub.detach();
-                    });
                 }
 
                 /**
@@ -2125,28 +2102,26 @@
 
                     destroyOff = innerScope.$on('$destroy', function () {
                         syncListener.dropListeners(destroyScope);
-                        if (delayRelease) {
-                            scheduleRelease();
-                        } else {
-                            destroy();
-                        }
-                    });
-
-                    _.forEach(dependentSubscriptions, function (dsub) {
-                        dsub.attach(newScope, delayRelease);
+                        thisSub.destroy();
                     });
                     return thisSub;
                 }
 
                 function listenForReconnectionToResync(listenNow) {
-                    // give a chance to connect before listening to reconnection.
-                    setTimeout(function () {
-                        reconnectOff = innerScope.$on('user_reconnected', function () {
+                    var scopeReconnectOff = void 0;
+                    // give a chance to connect before listening to reconnection (might need revising)
+                    var delay = setTimeout(function () {
+                        scopeReconnectOff = innerScope.$on('user_reconnected', function () {
                             isLogDebug && logDebug('Resyncing after network loss to ' + publication + JSON.stringify(thisSub.getParameters()));
                             // note the backend might return a new subscription if the client took too much time to reconnect.
                             registerSubscription();
                         });
                     }, listenNow ? 0 : 2000);
+
+                    return function () {
+                        clearTimeout(delay);
+                        scopeReconnectOff && scopeReconnectOff();
+                    };
                 }
 
                 /**
@@ -2231,6 +2206,9 @@
                 function processPublicationData(batch) {
                     // cannot only listen to subscriptionId yet...because the registration might have answer provided its id yet...but started broadcasting changes...@TODO can be improved...
                     if (subscriptionId === batch.subscriptionId || !subscriptionId && checkDataSetParamsIfMatchingBatchParams(batch.params)) {
+                        // if some sub listeners exist, it will be processed
+                        isLogInfo && logInfo('Syncing with [' + batch.name + ', id:' + batch.subscriptionId + ' , params:' + JSON.stringify(batch.params) + ']. Records:' + batch.records.length + '[' + (batch.diff ? 'Diff' : 'All') + ']');
+
                         var startTime = Date.now();
                         var dataReceivedIn = Date.now() - initialStartTime;
                         var size = benchmark && isLogInfo ? JSON.stringify(batch.records).length : null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zerv-ng-sync",
-  "version": "1.2.13",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1129,9 +1129,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
     "base64id": {
@@ -1251,13 +1251,13 @@
       }
     },
     "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-equal": {
@@ -3551,9 +3551,9 @@
       }
     },
     "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
     "ignore": {
@@ -4293,9 +4293,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yargs": {
@@ -7158,9 +7158,9 @@
       }
     },
     "y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
@@ -7242,17 +7242,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
-        },
-        "zjsonbin": {
-          "version": "github:z-open/zjsonbin#796a5ff1f5bc7db12b4b2ec66172608977213c80",
-          "from": "github:z-open/zjsonbin#2.0.3",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.15",
-            "lz4": "0.6.3",
-            "promise": "7.1.1",
-            "zimit-zlog": "1.0.6"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "url": ""
   },
-  "version": "1.2.13",
+  "version": "1.3.0",
   "dependencies": {
     "angular": "1.7.9",
     "lodash": "4.17.19"
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "test": "./node_modules/karma/bin/karma start",
-    "eslint": "./node_modules/eslint/bin/eslint.js --fix **/*.js"
+    "eslint": "./node_modules/eslint/bin/eslint.js --fix src/**/*.js test/**/*.js"
   },
   "readmeFilename": "README.md",
   "license": "MIT"

--- a/src/services/sync.service.js
+++ b/src/services/sync.service.js
@@ -716,7 +716,7 @@ function syncProvider($syncMappingProvider, $pqProvider) {
              *
              */
             function setForce(value) {
-                if (value && this.isSyncingOn) {
+                if (value && isSyncingOn) {
                     thisSub.syncOff();
                 }
                 return thisSub;

--- a/src/services/sync.service.js
+++ b/src/services/sync.service.js
@@ -1485,7 +1485,7 @@ function syncProvider($syncMappingProvider, $pqProvider) {
              *
              *
              */
-            function attach(newScope, delayRelease) {
+            function attach(newScope) {
                 detach();
 
                 if (newScope === innerScope) {

--- a/test/helpers/mock-sync-server.helper.js
+++ b/test/helpers/mock-sync-server.helper.js
@@ -4,16 +4,14 @@ angular
     .provider('mockSyncServer', mockSyncServer);
 
 function mockSyncServer() {
-
     var debug;
 
-    this.setDebug = function (value) {
+    this.setDebug = function(value) {
         debug = value;
     };
 
 
     this.$get = function sync($rootScope, $pq, $socketio, $sync, publicationService) {
-
         var publicationsWithSubscriptions = publicationService;
         var subCount = 0;
 
@@ -34,15 +32,14 @@ function mockSyncServer() {
             acknowledge: acknowledge,
 
 
+            setData: setData,
+        };
 
-            setData: setData
-        }
-
-        $socketio.onFetch('sync.subscribe', function () {
+        $socketio.onFetch('sync.subscribe', function() {
             return service.subscribe.apply(self, arguments);
         });
 
-        $socketio.onFetch('sync.unsubscribe', function () {
+        $socketio.onFetch('sync.unsubscribe', function() {
             return service.unsubscribe.apply(self, arguments);
         });
 
@@ -97,7 +94,7 @@ function mockSyncServer() {
          */
         function publish(definition) {
             if (_.isArray(definition)) {
-                _.forEach(definition, function (def) {
+                _.forEach(definition, function(def) {
                     if (!def.type) {
                         throw new Error('Publish array argument must contain objects with a type property ("object" or "array")');
                     }
@@ -106,7 +103,7 @@ function mockSyncServer() {
                     } else {
                         publishObject(def.sub, def.data);
                     }
-                })
+                });
             } else if (_.isObject(definition)) {
                 publishObject(definition.sub, definition.data);
             } else {
@@ -121,15 +118,13 @@ function mockSyncServer() {
          *   if not provided, a default publication will be created
          */
         function setData(subParams, data) {
-            data.forEach(function (record) {
+            data.forEach(function(record) {
                 if (_.isNil(record.revision)) {
                     throw new Error('Objects in publication must have a revision and id. Check you unit test data for ' + JSON.stringify(subParams));
                 }
             });
             return publicationsWithSubscriptions.create(data, subParams.publication, subParams.params);
         }
-
-
 
 
         function notifyDataUpdate(subParams, data) {
@@ -150,18 +145,20 @@ function mockSyncServer() {
             }
 
             data = publication.remove(data);
-            _.forEach(data, function (record) { record.remove = new Date(); });
+            _.forEach(data, function(record) {
+                record.remove = new Date();
+            });
             return notifySubscriptions(publication, data);
         }
 
         function notifySubscriptions(publication, data) {
-            var r = $pq.all(_.map(publication.subscriptionIds, function (id) {
+            var r = $pq.all(_.map(publication.subscriptionIds, function(id) {
                 return onPublicationNotficationCallback({
                     name: publication.name,
                     subscriptionId: id,
                     params: publication.params,
                     records: data,
-                    diff: true
+                    diff: true,
                 }, service.acknowledge);
             }));
             if (!$rootScope.$$phase) {
@@ -171,7 +168,6 @@ function mockSyncServer() {
                 // when the digest completes, the notification has been processed by the client, UI might have reacted too.
             }
             return r;
-
         }
 
         function subscribe(subParams) {
@@ -195,21 +191,19 @@ function mockSyncServer() {
                 publication.subscriptionIds.push(subId);
             }
 
-            return $pq.resolve(subId).then(function (subId) {
-                publication.subId = subId;
-                onPublicationNotficationCallback({
-                    name: publication.name,
-                    subscriptionId: subId,  // this is the id for the new subscription.
-                    params: publication.params,
-                    records: publication.getData(),
-                }, service.acknowledge);
-                return subId;
-            });
+            publication.subId = subId;
+            onPublicationNotficationCallback({
+                name: publication.name,
+                subscriptionId: subId, // this is the id for the new subscription.
+                params: publication.params,
+                records: publication.getData(),
+            }, service.acknowledge);
+            return $pq.resolve(subId);
         }
 
         function unsubscribe(subParams) {
             publicationsWithSubscriptions.release(subParams.id, subParams.publication, subParams.params);
-            logDebug("Unsubscribed: " + JSON.stringify(subParams));
+            logDebug('Unsubscribed: ' + JSON.stringify(subParams));
             return $pq.resolve();
         }
 
@@ -231,11 +225,7 @@ function mockSyncServer() {
                 console.debug('MOCKSERV: ' + msg);
             }
         }
-    }
+    };
 }
-
-
-
-
 
 

--- a/test/helpers/publication.service.helper.js
+++ b/test/helpers/publication.service.helper.js
@@ -13,14 +13,14 @@ function publicationService($sync) {
 
     function findBySubscriptionId(id) {
         // find the data for this subscription
-        return _.find(publications, function (pub) {
+        return _.find(publications, function(pub) {
             return _.indexOf(pub.subscriptionIds, id) !== -1;
         });
     }
 
     function find(name, params) {
         // find the data for this subscription
-        return _.find(publications, function (pub) {
+        return _.find(publications, function(pub) {
             return pub.name === name && (
                 (params && pub.params && _.isEqual(params, pub.params)) ||
                 (!params && !pub.params)
@@ -51,15 +51,14 @@ function publicationService($sync) {
     }
 
 
-
     function copyAll(array) {
         var r = [];
-        array.forEach(function (i) {
+        array.forEach(function(i) {
             if (!_.isObject(i)) {
                 throw new Error('Publication data cannot be null');
             }
             r.push(angular.copy(i));
-        })
+        });
         return r;
     }
 
@@ -70,42 +69,37 @@ function publicationService($sync) {
         this.subscriptionIds = [];
     }
 
-    Publication.prototype.hasSubscriptions = function () {
+    Publication.prototype.hasSubscriptions = function() {
         return this.subscriptionIds.length > 0;
-    }
+    };
 
-    Publication.prototype.reset = function (data) {
+    Publication.prototype.reset = function(data) {
         this.cache = {};
         this.update(data);
         return data;
-    }
+    };
 
-    Publication.prototype.update = function (data) {
+    Publication.prototype.update = function(data) {
         var self = this;
         data = copyAll(data);
-        data.forEach(function (record) {
+        data.forEach(function(record) {
             self.cache[$sync.getIdValue(record.id)] = record;
         });
         return data;
-    }
+    };
 
-    Publication.prototype.remove = function (data) {
+    Publication.prototype.remove = function(data) {
         var self = this;
         data = copyAll(data);
-        data.forEach(function (record) {
+        data.forEach(function(record) {
             delete self.cache[$sync.getIdValue(record.id)];
         });
         return data;
-    }
+    };
 
-    Publication.prototype.getData = function () {
+    Publication.prototype.getData = function() {
         return _.values(this.cache);
-    }
+    };
 }
-
-
-
-
-
 
 


### PR DESCRIPTION
Jira Task: https://github.com/zimit-io/zimit-webapp/pull/5783

**Description**
- Removed the auto release feature which would execute syncOff within a delay after the sub was detached from the scope but not destroyed. It was not valuable.
- Added an event to listen to on subscription destroy
- Fixed a memory waste and performance degradation due to reconnection timeout not be cleared when subscription is paused or destroyed.
- Added a function to activate the use of native primitives instead of angular's implementation. This will be the default later on. It is easier to write unit tests and more predictable than relying on angular's primitive combined with native ones most of time.
- Added a function to detect if the cache is empty.
- Enhanced code formatting

**Steps to Reproduce**

Run:
npm test

**Performance Considerations**
Some performance improvement (earlier release of subscriptions) and prevent potential memory leak.

**Sections of the Application Affected**
Look up application pr to QA.